### PR TITLE
ivi-application: introduce new helper library

### DIFF
--- a/protocol/CMakeLists.txt
+++ b/protocol/CMakeLists.txt
@@ -153,6 +153,23 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
                       COMPILE_FLAGS "-fPIC")
 
 
+project (ivi-application)
+
+add_library(${PROJECT_NAME} SHARED
+    ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-client-protocol.h
+    ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-protocol.c
+)
+
+install(
+    TARGETS ${PROJECT_NAME}
+    LIBRARY DESTINATION lib${LIB_SUFFIX}
+)
+
+install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-client-protocol.h
+    DESTINATION include/ilm
+)
+
 #=============================================================================================
 # generate documentation for ivi-application API
 #=============================================================================================


### PR DESCRIPTION
ivi-application is the new shared library which has the implementation
of ivi-application-protocol. The clients can use the library to create
ivi-surfaces.

Signed-off-by: Emre Ucan <eucan@de.adit-jv.com>