### PR TITLE
Deprecate ilm client v2

### DIFF
--- a/ivi-input-api/ilmInput/src/ilm_input.c
+++ b/ivi-input-api/ilmInput/src/ilm_input.c
@@ -25,14 +25,6 @@
 #include "ilm_input.h"
 #include "ilm_control_platform.h"
 
-
-/* GCC visibility */
-#if defined(__GNUC__) && __GNUC__ >= 4
-#define ILM_EXPORT __attribute__ ((visibility("default")))
-#else
-#define ILM_EXPORT
-#endif
-
 extern struct ilm_control_context ilm_context;
 
 ILM_EXPORT ilmErrorTypes

--- a/ivi-layermanagement-api/ilmClient/include/ilm_client.h
+++ b/ivi-layermanagement-api/ilmClient/include/ilm_client.h
@@ -34,7 +34,7 @@ extern "C" {
  * \return ILM_SUCCESS if the method call was successful
  * \return ILM_FAILED if a connection can not be established to the services.
  */
-ilmErrorTypes ilmClient_init(t_ilm_nativedisplay nativedisplay);
+ilmErrorTypes ilmClient_init(t_ilm_nativedisplay nativedisplay) ILM_DEPRECATED;
 
 /**
  * \brief Create a surface
@@ -53,7 +53,7 @@ ilmErrorTypes ilm_surfaceCreate(t_ilm_nativehandle nativehandle,
                                 t_ilm_int width,
                                 t_ilm_int height,
                                 ilmPixelFormat pixelFormat,
-                                t_ilm_surface *pSurfaceId);
+                                t_ilm_surface *pSurfaceId) ILM_DEPRECATED;
 
 /**
  * \brief Remove a surface
@@ -62,7 +62,7 @@ ilmErrorTypes ilm_surfaceCreate(t_ilm_nativehandle nativehandle,
  * \return ILM_SUCCESS if the method call was successful
  * \return ILM_FAILED if the client can not call the method on the service.
  */
-ilmErrorTypes ilm_surfaceRemove(const t_ilm_surface surfaceId);
+ilmErrorTypes ilm_surfaceRemove(const t_ilm_surface surfaceId) ILM_DEPRECATED;
 
 /**
  * \brief Destroys the IVI LayerManagement Client APIs.
@@ -70,7 +70,7 @@ ilmErrorTypes ilm_surfaceRemove(const t_ilm_surface surfaceId);
  * \return ILM_SUCCESS if the method call was successful
  * \return ILM_FAILED if the client can not be closed or was not initialized.
  */
-ilmErrorTypes ilmClient_destroy(void);
+ilmErrorTypes ilmClient_destroy(void) ILM_DEPRECATED;
 
 #ifdef __cplusplus
 } /**/

--- a/ivi-layermanagement-api/ilmClient/src/ilm_client.c
+++ b/ivi-layermanagement-api/ilmClient/src/ilm_client.c
@@ -27,13 +27,6 @@
 #include "ilm_client.h"
 #include "ilm_client_platform.h"
 
-/* GCC visibility */
-#if defined(__GNUC__) && __GNUC__ >= 4
-#define ILM_EXPORT __attribute__ ((visibility("default")))
-#else
-#define ILM_EXPORT
-#endif
-
 ILM_EXPORT ilmErrorTypes
 ilmClient_init(t_ilm_nativedisplay nativedisplay)
 {

--- a/ivi-layermanagement-api/ilmCommon/include/ilm_types.h
+++ b/ivi-layermanagement-api/ilmCommon/include/ilm_types.h
@@ -51,6 +51,13 @@
 #define ILM_EXPORT
 #endif
 
+/* Deprecated attribute */
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define ILM_DEPRECATED __attribute__ ((deprecated))
+#else
+#define ILM_DEPRECATED
+#endif
+
 /**
  * \brief Enumeration on possible error codes
  * \ingroup ilmClient

--- a/ivi-layermanagement-api/ilmCommon/include/ilm_types.h
+++ b/ivi-layermanagement-api/ilmCommon/include/ilm_types.h
@@ -44,6 +44,13 @@
  **/
 #define ILM_FALSE     0u
 
+/* GCC visibility */
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define ILM_EXPORT __attribute__ ((visibility("default")))
+#else
+#define ILM_EXPORT
+#endif
+
 /**
  * \brief Enumeration on possible error codes
  * \ingroup ilmClient

--- a/ivi-layermanagement-api/ilmCommon/src/ilm_common.c
+++ b/ivi-layermanagement-api/ilmCommon/src/ilm_common.c
@@ -25,13 +25,6 @@
 #include "ilm_common_platform.h"
 #include "ilm_types.h"
 
-/* GCC visibility */
-#if defined(__GNUC__) && __GNUC__ >= 4
-#define ILM_EXPORT __attribute__ ((visibility("default")))
-#else
-#define ILM_EXPORT
-#endif
-
 ILM_EXPORT ilmErrorTypes ilmControl_init(t_ilm_nativedisplay);
 ILM_EXPORT void ilmControl_destroy(void);
 

--- a/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
+++ b/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
@@ -34,13 +34,6 @@
 #include "ivi-controller-client-protocol.h"
 #include "ivi-input-client-protocol.h"
 
-/* GCC visibility */
-#if defined(__GNUC__) && __GNUC__ >= 4
-#define ILM_EXPORT __attribute__ ((visibility("default")))
-#else
-#define ILM_EXPORT
-#endif
-
 struct layer_context {
     struct wl_list link;
 


### PR DESCRIPTION
it introduces new ILM_DEPRECATED macro and uses it to deprecate ilmClient APIs