### PR TITLE
ilmControl: mark surfaceGetPixelformat API as deprecated

### DIFF
--- a/ivi-layermanagement-api/ilmControl/include/ilm_control.h
+++ b/ivi-layermanagement-api/ilmControl/include/ilm_control.h
@@ -376,7 +376,7 @@ ilmErrorTypes ilm_surfaceGetOrientation(t_ilm_surface surfaceId, ilmOrientation 
  * \return ILM_SUCCESS if the method call was successful
  * \return ILM_FAILED if the client can not call the method on the service.
  */
-ilmErrorTypes ilm_surfaceGetPixelformat(t_ilm_layer surfaceId, ilmPixelFormat *pPixelformat);
+ilmErrorTypes ilm_surfaceGetPixelformat(t_ilm_layer surfaceId, ilmPixelFormat *pPixelformat) ILM_DEPRECATED;
 
 /**
  * \brief Sets render order of layers on a display


### PR DESCRIPTION
A wayland compositor does not have any control over
the pixel format of the application surfaces.

Therefore, this API is deprecated.

Signed-off-by: Emre Ucan <eucan@de.adit-jv.com>