### PR TITLE
LayerManagerControl: remove surface create and destroy api's

### DIFF
--- a/ivi-layermanagement-examples/LayerManagerControl/src/commands.cpp
+++ b/ivi-layermanagement-examples/LayerManagerControl/src/commands.cpp
@@ -621,51 +621,17 @@ COMMAND("create layer <layerid> <width> <height>")
 }
 
 //=============================================================================
-COMMAND("create surface <surfaceid> <nativehandle> <width> <height> <pixelformat>")
+COMMAND("destroy layer <id>")
 //=============================================================================
 {
-    unsigned int surfaceid = input->getUint("surfaceid");
-    unsigned int nativeHandle = input->getUint("nativehandle");
-    unsigned int width = input->getUint("width");
-    unsigned int height = input->getUint("height");
-    e_ilmPixelFormat pixelformat = (e_ilmPixelFormat)input->getUint("pixelformat");
+    unsigned int layerid = input->getUint("id");
 
-    ilmErrorTypes callResult = ilm_surfaceCreate(nativeHandle, width, height, pixelformat, &surfaceid);
+    ilmErrorTypes callResult = ilm_layerRemove(layerid);
     if (ILM_SUCCESS != callResult)
     {
         cout << "LayerManagerService returned: " << ILM_ERROR_STRING(callResult) << "\n";
-        cout << "Failed to create surface with ID " << surfaceid << "\n";
+        cout << "Failed to remove layer with ID " << layerid << "\n";
         return;
-    }
-}
-
-//=============================================================================
-COMMAND("destroy layer|surface <id>")
-//=============================================================================
-{
-    if (input->contains("layer"))
-    {
-        unsigned int layerid = input->getUint("id");
-
-        ilmErrorTypes callResult = ilm_layerRemove(layerid);
-        if (ILM_SUCCESS != callResult)
-        {
-            cout << "LayerManagerService returned: " << ILM_ERROR_STRING(callResult) << "\n";
-            cout << "Failed to remove layer with ID " << layerid << "\n";
-            return;
-        }
-    }
-    else if (input->contains("surface"))
-    {
-        unsigned int surfaceid = input->getUint("id");
-
-        ilmErrorTypes callResult = ilm_surfaceRemove(surfaceid);
-        if (ILM_SUCCESS != callResult)
-        {
-            cout << "LayerManagerService returned: " << ILM_ERROR_STRING(callResult) << "\n";
-            cout << "Failed to remove surface with ID " << surfaceid << "\n";
-            return;
-        }
     }
 
     ilm_commitChanges();


### PR DESCRIPTION
api's never worked and would even cause exception in LayerManagerControl tool
surface can only be created with native content and native content is
wayland-surface which is only available in the client.
So it does not make any sense to provide this functionality to external tool.
For surface destroy it is very similar issue, we can only destroy surfaces
which were created in the same client, but this is never the case by using
LayerManagerControl- every call will create new connection and therefore new client

Signed-off-by: Eugen Friedrich <efriedrich@de.adit-jv.com>