### PR TITLE
ivi-share: fix compilation issue

### DIFF
--- a/weston-ivi-shell/src/ivi-share-gbm.c
+++ b/weston-ivi-shell/src/ivi-share-gbm.c
@@ -32,7 +32,6 @@
 #include "wayland-server.h"
 #include "weston/compositor.h"
 #include "ivi-share-server-protocol.h"
-#include "ivi-controller-interface.h"
 #include "ivi-share.h"
 
 static uint32_t nativesurface_name;

--- a/weston-ivi-shell/src/ivi-share.c
+++ b/weston-ivi-shell/src/ivi-share.c
@@ -521,7 +521,7 @@ static struct ivi_share_interface g_share_implementation = {
 
 static struct ivi_shell_share_ext*
 init_ivi_shell_share_ext(struct weston_compositor *wc,
-                         const struct ivi_controller_interface *controller_interface,
+                         const struct ivi_layout_interface *controller_interface,
                          struct ivi_shell_share_ext *shell_ext)
 {
     shell_ext = calloc(1, sizeof(*shell_ext));
@@ -693,7 +693,7 @@ add_weston_surf_data(struct wl_listener *listener, void *data)
 
 int32_t
 setup_buffer_sharing(struct weston_compositor *wc,
-                     const struct ivi_controller_interface *interface)
+                     const struct ivi_layout_interface *interface)
 {
     if (NULL == wc || NULL == interface) {
         weston_log("Can not execute buffer sharing.\n");

--- a/weston-ivi-shell/src/ivi-share.h
+++ b/weston-ivi-shell/src/ivi-share.h
@@ -21,8 +21,7 @@
 
 #include <wayland-server.h>
 #include <weston/compositor.h>
-
-#include "ivi-controller-interface.h"
+#include <weston/ivi-layout-export.h>
 
 /**
  * convenience macro to access single bits of a bitmask
@@ -50,7 +49,7 @@ struct ivi_share_nativesurface
 struct ivi_shell_share_ext
 {
     struct weston_compositor *wc;
-    const struct ivi_controller_interface *controller_interface;
+    const struct ivi_layout_interface *controller_interface;
     struct wl_resource *resource;
     struct wl_list list_shell_surface;           /* shell_surface list */
     struct wl_list list_nativesurface;           /* ivi_nativesurface list */
@@ -68,7 +67,7 @@ enum ivi_sharebuffer_updatetype
 };
 
 int32_t setup_buffer_sharing(struct weston_compositor *wc,
-                             const struct ivi_controller_interface *interface);
+                             const struct ivi_layout_interface *interface);
 
 uint32_t get_buffer_name(struct weston_surface *surface,
                          struct ivi_shell_share_ext *shell_ext);


### PR DESCRIPTION
The ivi-controller.so does not compile, if
ivi_share is activated. Because it includes
a non existing header file. The ivi-controller-interface
is renamed to ivi-layout-interface, and its contents
moved to ivi-layout-export.h

Signed-off-by: Emre Ucan <eucan@de.adit-jv.com>