### PR TITLE
Fix ivi-application lib install

### DIFF
--- a/protocol/CMakeLists.txt
+++ b/protocol/CMakeLists.txt
@@ -170,6 +170,8 @@ install(
     DESTINATION include/ilm
 )
 
+SET_TARGET_PROPERTIES(${PROJECT_NAME} PROPERTIES VERSION ${ILM_API_VERSION} SOVERSION ${ILM_API_VERSION})
+
 #=============================================================================================
 # generate documentation for ivi-application API
 #=============================================================================================


### PR DESCRIPTION
 * libivi-application.so must be a link to
    libivi-application.so.X.X.XX
 * fix yocto package QA

Signed-off-by: Ronan Le Martret <ronan.lemartret@iot.bzh>