### PR TITLE
ilmControl: fix memory leak at deinitialization

### DIFF
--- a/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
+++ b/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
@@ -1032,7 +1032,7 @@ static void destroy_control_resources(void)
     struct ilm_control_context *ctx = &ilm_context;
 
     // free resources of output objects
-    if (! ctx->wl.controller) {
+    if (ctx->wl.controller) {
         struct screen_context *ctx_scrn;
         struct screen_context *next;
 


### PR DESCRIPTION
Check ctx->wl.controller for not null.
If it is null, we cannot destroy any wayland objects.
The if statement is wrong.

Signed-off-by: Emre Ucan <eucan@de.adit-jv.com>