### PR TITLE
ilmControl: fix memory corruption at input listener

### DIFF
--- a/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
+++ b/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
@@ -934,7 +934,7 @@ input_listener_input_acceptance(void *data,
         return;
     }
 
-    accepted_seat = calloc(1, sizeof(accepted_seat));
+    accepted_seat = calloc(1, sizeof(*accepted_seat));
     if (accepted_seat == NULL) {
         fprintf(stderr, "Failed to allocate memory for accepted seat\n");
         return;


### PR DESCRIPTION
Allocate memory in the size of accepted_seat struct instead of
size of a pointer of the struct

Signed-off-by: Emre Ucan <eucan@de.adit-jv.com>