### PR TITLE
Add pkg config files v2

### DIFF
--- a/ivi-input-api/ilmInput/CMakeLists.txt
+++ b/ivi-input-api/ilmInput/CMakeLists.txt
@@ -88,3 +88,18 @@ add_custom_target(ilm-input-doc
                              ${CMAKE_BINARY_DIR}/ilm-input-api-${ILM_API_VERSION}.pdf
                   COMMENT "Generating ilm-input-api-${ILM_API_VERSION}.pdf"
 )
+
+#=============================================================================================
+# generate pkg-config file for ilmInput API
+#=============================================================================================
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/ilmInput.pc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/ilmInput.pc"
+    @ONLY
+)
+
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/ilmInput.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)

--- a/ivi-input-api/ilmInput/ilmInput.pc.in
+++ b/ivi-input-api/ilmInput/ilmInput.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/ilm
+
+Name: ilmInput
+Description: Library for ilm input handling
+Version: @ILM_API_VERSION@
+Requires: ilmCommon
+Requires.private: wayland-client ilmControl
+Libs: -L${libdir} -lilmInput
+Cflags: -I${includedir}

--- a/ivi-layermanagement-api/ilmCommon/CMakeLists.txt
+++ b/ivi-layermanagement-api/ilmCommon/CMakeLists.txt
@@ -65,3 +65,18 @@ install (
 )
 
 SET_TARGET_PROPERTIES(${PROJECT_NAME} PROPERTIES VERSION ${ILM_API_VERSION} SOVERSION ${ILM_API_VERSION})
+
+#=============================================================================================
+# generate pkg-config file for ilmCommon API
+#=============================================================================================
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/ilmCommon.pc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/ilmCommon.pc"
+    @ONLY
+)
+
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/ilmCommon.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)

--- a/ivi-layermanagement-api/ilmCommon/ilmCommon.pc.in
+++ b/ivi-layermanagement-api/ilmCommon/ilmCommon.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/ilm
+
+Name: ilmCommon
+Description: Library for common part of ilm api
+Version: @ILM_API_VERSION@
+Requires.private: wayland-client
+Libs: -L${libdir} -lilmCommon
+Cflags: -I${includedir}

--- a/ivi-layermanagement-api/ilmControl/CMakeLists.txt
+++ b/ivi-layermanagement-api/ilmControl/CMakeLists.txt
@@ -89,3 +89,17 @@ add_custom_target(ilm-control-doc
                   COMMENT "Generating ilm-control-api-${ILM_API_VERSION}.pdf"
 )
 
+#=============================================================================================
+# generate pkg-config file for ilmControl API
+#=============================================================================================
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/ilmControl.pc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/ilmControl.pc"
+    @ONLY
+)
+
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/ilmControl.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)

--- a/ivi-layermanagement-api/ilmControl/ilmControl.pc.in
+++ b/ivi-layermanagement-api/ilmControl/ilmControl.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/ilm
+
+Name: ilmControl
+Description: Library for control part of ilm api
+Version: @ILM_API_VERSION@
+Requires: ilmCommon
+Requires.private: wayland-client
+Libs: -L${libdir} -lilmControl
+Cflags: -I${includedir}

--- a/protocol/CMakeLists.txt
+++ b/protocol/CMakeLists.txt
@@ -255,3 +255,18 @@ add_custom_target(ivi-input-doc
 
                   COMMENT "Generating ivi-input-api-${IVI_EXTENSION_VERSION}.pdf"
 )
+
+#=============================================================================================
+# generate pkg-config file for ivi-application API
+#=============================================================================================
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/ivi-application.pc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/ivi-application.pc"
+    @ONLY
+)
+
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/ivi-application.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)

--- a/protocol/ivi-application.pc.in
+++ b/protocol/ivi-application.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/ilm
+
+Name: ivi-application
+Description: Protocol for ivi-shell
+Version: @IVI_EXTENSION_VERSION@
+Requires: wayland-client
+Libs: -L${libdir} -livi-application
+Cflags: -I${includedir}


### PR DESCRIPTION
Removed pkg config files for ilmClient from previous pull request.

Added initial pkg-config files / templates (.pc.in) for all shared libraries in wayland-ivi-extension
Adjusted cmake files to generate pkg-config files (.pc) from templates (.pc.in)