### PR TITLE
Bump to ilm to 1.13.0 stable version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 project(wayland-ivi-extension)
 
-SET(IVI_EXTENSION_VERSION 1.11.0)
-SET(ILM_API_VERSION 1.11.0)
+SET(IVI_EXTENSION_VERSION 1.13.0)
+SET(ILM_API_VERSION 1.13.0)
 
 add_subdirectory(protocol)
 


### PR DESCRIPTION
This release includes following changes:
- add pkg-config files for ilmInput, ilmControl and ilmCommon libraries
- update to work with weston 2.0 release
- deprecate ilmClient API's, ilm_surfaceGetPixelformat and orientation API's:
	ilm_layerSetOrinetation, ilm_layerGetOrientation
	ilm_surfaceSetOrinetation, ilm_surfaceGetOrinetation
- fixed memory leaks and memory corruption in ilmControl

Signed-off-by: Eugen Friedrich <efriedrich@de.adit-jv.com>