### PR TITLE
ilmControl:Added roundtrip to get screen-ids

### DIFF
--- a/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
+++ b/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
@@ -1229,6 +1229,13 @@ init_control(void)
         }
     }
 
+    // get screen-ids
+    if (wl_display_roundtrip_queue(wl->display, wl->queue) == -1)
+    {
+        fprintf(stderr, "Failed to do roundtrip queue: %s\n", strerror(errno));
+        return -1;
+    }
+
     ctx->shutdown_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
 
     if (ctx->shutdown_fd == -1)


### PR DESCRIPTION
For the screen-id related commands such as "LayermanagerControl dump", the
command is failing since the screen-id is not properly updated. So ensuring
to get the screen-ids by doing a roundtrip.

Signed-off-by: Maniraj Devadoss <external.mdevadoss@de.adit-jv.com>