### PR TITLE
Added support for cursor pointer image in EGLWLInputEventExample

### DIFF
--- a/ivi-layermanagement-examples/EGLWLInputEventExample/CMakeLists.txt
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/CMakeLists.txt
@@ -27,6 +27,7 @@ pkg_check_modules(GLESv2 glesv2 REQUIRED)
 pkg_check_modules(EGL egl REQUIRED)
 pkg_check_modules(WAYLAND_EGL wayland-egl REQUIRED)
 pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
+pkg_check_modules(WAYLAND_CURSOR wayland-cursor REQUIRED)
 
 GET_TARGET_PROPERTY(ILM_CLIENT_INCLUDE_DIRS  ilmClient  INCLUDE_DIRECTORIES)
 
@@ -35,6 +36,7 @@ include_directories(
     ${GLESv2_INCLUDE_DIR}
     ${EGL_INCLUDE_DIR}
     ${WAYLAND_CLIENT_INCLUDE_DIR}
+    ${WAYLAND_CURSOR_INCLUDE_DIR}
     ${FFI_INCLUDE_DIR}
     "include"
 )
@@ -43,6 +45,7 @@ link_directories(
     ${GLESv2_LIBRARY_DIRS}
     ${EGL_LIBRARY_DIRS}
     ${WAYLAND_CLIENT_LIBRARY_DIRS}
+    ${WAYLAND_CURSOR_LIBRARY_DIRS}
 )
 
 set (HEADER_FILES
@@ -70,6 +73,7 @@ add_executable(EGLWLInputEventExample
 
 add_dependencies(EGLWLInputEventExample
     wayland-client
+    wayland-cursor
     wayland-egl
     ivi-application
     ${LIBS}
@@ -79,6 +83,7 @@ set(LIBS
     ${LIBS}
     ${GLESv2_LIBRARIES}
     ${WAYLAND_CLIENT_LIBRARIES}
+    ${WAYLAND_CURSOR_LIBRARIES}
     ${WAYLAND_EGL_LIBRARIES}
     ${FFI_LIBRARIES}
     ${EGL_LIBRARIES}

--- a/ivi-layermanagement-examples/EGLWLInputEventExample/include/WLContext.h
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/include/WLContext.h
@@ -44,6 +44,11 @@ private:
     struct wl_keyboard_listener* m_wlKeyboardListener;
     struct wl_touch_listener*    m_wlTouchListener;
 
+    struct wl_cursor_theme* m_wlCursorTheme;
+    struct wl_cursor* m_wlCursor;
+    struct wl_shm* m_wlShm;
+    struct wl_surface *m_pointerSurface;
+
 // methods
 public:
     WLContext();
@@ -60,6 +65,10 @@ public:
     struct wl_keyboard_listener* GetWLKeyboardListener() const;
     struct wl_touch_listener* GetWLTouchListener() const;
     struct ivi_application* GetIviApp() const;
+    struct wl_cursor_theme* GetWLCursorTheme() const;
+    struct wl_cursor* GetWLCursor() const;
+    struct wl_shm* GetWLShm() const;
+    struct wl_surface* GetPointerSurface() const;
 
     void SetEventMask(uint32_t mask);
     void SetWLCompositor(struct wl_compositor* wlCompositor);
@@ -68,6 +77,10 @@ public:
     void SetWLPointer(struct wl_pointer* wlPointer);
     void SetWLKeyboard(struct wl_keyboard* wlKeyboard);
     void SetWLTouch(struct wl_touch* wlTouch);
+    void SetWLCursorTheme(struct wl_cursor_theme* wlCursorTheme);
+    void SetWLCursor(struct wl_cursor* wlCursor);
+    void SetWLShm(struct wl_shm* wlShm);
+    void SetPointerSurface(struct wl_surface* pointerSurface);
 
     static void RegistryHandleGlobal(void* data,
                                      struct wl_registry* registry,
@@ -93,9 +106,21 @@ inline struct wl_keyboard_listener* WLContext::GetWLKeyboardListener() const
 inline struct wl_touch_listener* WLContext::GetWLTouchListener() const
     { return m_wlTouchListener; }
 inline struct ivi_application* WLContext::GetIviApp() const { return m_iviApp; }
+inline struct wl_cursor_theme* WLContext::GetWLCursorTheme() const { return m_wlCursorTheme; }
+inline struct wl_cursor* WLContext::GetWLCursor() const { return m_wlCursor; }
+inline struct wl_shm* WLContext::GetWLShm() const { return m_wlShm; }
+inline struct wl_surface* WLContext::GetPointerSurface() const
+    { return m_pointerSurface; }
 inline void WLContext::SetWLCompositor(struct wl_compositor* wlCompositor)
     { m_wlCompositor = wlCompositor; }
 inline void WLContext::SetIviApp(struct ivi_application* iviApp)
     { m_iviApp = iviApp; }
+inline void WLContext::SetWLCursorTheme(struct wl_cursor_theme* wlCursorTheme)
+    { m_wlCursorTheme = wlCursorTheme; }
+inline void WLContext::SetWLCursor(struct wl_cursor* wlCursor)
+    { m_wlCursor = wlCursor; }
+inline void WLContext::SetWLShm(struct wl_shm* wlShm) { m_wlShm = wlShm; }
+inline void WLContext::SetPointerSurface(struct wl_surface* pointerSurface)
+    { m_pointerSurface = pointerSurface; }
 
 #endif /* _WLCONTEXT_H_ */

--- a/ivi-layermanagement-examples/EGLWLInputEventExample/include/WLContext.h
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/include/WLContext.h
@@ -23,6 +23,7 @@
 #include <wayland-client.h>
 #include <wayland-client-protocol.h>
 #include <ivi-application-client-protocol.h>
+#include <wayland-cursor.h>
 
 class WLContext
 {

--- a/ivi-layermanagement-examples/EGLWLInputEventExample/include/WLContext.h
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/include/WLContext.h
@@ -25,15 +25,17 @@
 #include <ivi-application-client-protocol.h>
 #include <wayland-cursor.h>
 
+
+struct seat_data {
+    struct wl_seat *wlSeat;
+    struct wl_keyboard *wlKeyboard;
+    struct wl_pointer *wlPointer;
+    struct wl_touch *wlTouch;
+    class WLContext *ctx;
+};
+
 class WLContext
 {
-	struct seat_data {
-		struct wl_seat *wlSeat;
-		struct wl_keyboard *wlKeyboard;
-		struct wl_pointer *wlPointer;
-		struct wl_touch *wlTouch;
-		class WLContext *ctx;
-	};
 // properties
 private:
     struct wl_display*    m_wlDisplay;

--- a/ivi-layermanagement-examples/EGLWLInputEventExample/src/WLContext.cpp
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/src/WLContext.cpp
@@ -47,6 +47,9 @@ WLContext::WLContext()
 , m_wlPointerListener(NULL)
 , m_wlKeyboardListener(NULL)
 , m_wlTouchListener(NULL)
+, m_wlCursorTheme(NULL)
+, m_wlCursor(NULL)
+, m_wlShm(NULL)
 {
 }
 
@@ -162,6 +165,17 @@ WLContext::SeatHandleCapabilities(void* data, struct wl_seat* seat, uint32_t cap
     if (!(caps & WL_SEAT_CAPABILITY_POINTER) && context->wlPointer){
         wl_pointer_destroy(context->wlPointer);
         context->wlPointer = NULL;
+
+        if (context->ctx->GetPointerSurface()){
+            wl_surface_destroy(context->ctx->GetPointerSurface());
+            context->ctx->SetPointerSurface(NULL);
+        }
+
+        if (context->ctx->GetWLCursorTheme())
+            wl_cursor_theme_destroy(context->ctx->GetWLCursorTheme());
+
+        if (context->ctx->GetWLCursor())
+            free(context->ctx->GetWLCursor());
     }
 
     if ((caps & WL_SEAT_CAPABILITY_KEYBOARD) && !context->wlKeyboard){
@@ -216,6 +230,17 @@ WLContext::DestroyWLContext()
 
     if (m_wlCompositor)
         wl_compositor_destroy(m_wlCompositor);
+
+    if (m_pointerSurface){
+        wl_surface_destroy(m_pointerSurface);
+        m_pointerSurface = NULL;
+    }
+
+    if (m_wlCursorTheme)
+        wl_cursor_theme_destroy(m_wlCursorTheme);
+
+    if (m_wlCursor)
+        free(m_wlCursor);
 
     wl_registry_destroy(m_wlRegistry);
     wl_display_flush(m_wlDisplay);

--- a/ivi-layermanagement-examples/EGLWLInputEventExample/src/WLContext.cpp
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/src/WLContext.cpp
@@ -125,7 +125,7 @@ WLContext::RegistryHandleGlobal(void* data,
         }
 
         if (!strcmp(interface, "wl_seat")){
-            struct WLContext::seat_data *seat_data = (struct WLContext::seat_data *)calloc(1, sizeof *seat_data);
+            struct seat_data *seat_data = (struct seat_data *)calloc(1, sizeof *seat_data);
             seat_data->ctx = surface;
             seat_data->wlSeat = (wl_seat*)wl_registry_bind(
                                  registry, name, &wl_seat_interface, 1);
@@ -138,8 +138,8 @@ WLContext::RegistryHandleGlobal(void* data,
 void
 WLContext::SeatHandleCapabilities(void* data, struct wl_seat* seat, uint32_t caps)
 {
-	struct WLContext::seat_data* context =
-			static_cast<struct WLContext::seat_data*>(data);
+	struct seat_data* context =
+			static_cast<struct seat_data*>(data);
     assert(context);
 
     if ((caps & WL_SEAT_CAPABILITY_POINTER) && !context->wlPointer){

--- a/ivi-layermanagement-examples/EGLWLInputEventExample/src/WLContext.cpp
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/src/WLContext.cpp
@@ -124,6 +124,14 @@ WLContext::RegistryHandleGlobal(void* data,
                                                           1));
         }
 
+        if (!strcmp(interface, "wl_shm")){
+            surface->SetWLShm(
+                (struct wl_shm*)wl_registry_bind(registry,
+                                                          name,
+                                                          &wl_shm_interface,
+                                                          1));
+        }
+
         if (!strcmp(interface, "wl_seat")){
             struct seat_data *seat_data = (struct seat_data *)calloc(1, sizeof *seat_data);
             seat_data->ctx = surface;


### PR DESCRIPTION
Added support for cursor pointer image in EGLWLInputEventExample. If a mouse is attached a basic cursor pointer is loaded and shown on the application after clicking it. This approach is as minimal as possible.