### PR TITLE
Send screen connector name

### DIFF
--- a/ivi-layermanagement-api/ilmCommon/include/ilm_types.h
+++ b/ivi-layermanagement-api/ilmCommon/include/ilm_types.h
@@ -231,6 +231,7 @@ struct ilmScreenProperties
     t_ilm_layer* layerIds;          /*!< array of layer ids */
     t_ilm_uint screenWidth;         /*!< width value of screen in pixels */
     t_ilm_uint screenHeight;        /*!< height value of screen in pixels */
+    t_ilm_char connectorName[256];  /*!< name of the connector of the screen */
 };
 
 /**

--- a/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
+++ b/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
@@ -650,6 +650,16 @@ wm_screen_listener_layer_added(void *data, struct ivi_wm_screen *controller,
 }
 
 static void
+wm_screen_listener_connector_name(void *data, struct ivi_wm_screen *controller,
+                                  const char *connector_name)
+{
+    struct screen_context *ctx_screen = data;
+    (void) controller;
+
+    strcpy(ctx_screen->prop.connectorName, connector_name);
+}
+
+static void
 wm_screen_listener_error(void *data, struct ivi_wm_screen *controller,
                          uint32_t code, const char *message)
 {
@@ -688,6 +698,7 @@ static struct ivi_wm_screen_listener wm_screen_listener=
 {
     wm_screen_listener_screen_id,
     wm_screen_listener_layer_added,
+    wm_screen_listener_connector_name,
     wm_screen_listener_error
 };
 

--- a/ivi-layermanagement-examples/LayerManagerControl/src/print.cpp
+++ b/ivi-layermanagement-examples/LayerManagerControl/src/print.cpp
@@ -94,6 +94,8 @@ void printScreenProperties(unsigned int screenid, const char* prefix)
         return;
     }
 
+    cout << prefix << "- connector name:       " << screenProperties.connectorName << "\n";
+
     cout << prefix << "- resolution:           x=" << screenProperties.screenWidth << ", y="
             << screenProperties.screenHeight << "\n";
 

--- a/protocol/ivi-wm.xml
+++ b/protocol/ivi-wm.xml
@@ -87,6 +87,13 @@
       <arg name="layer_id" type="uint"/>
     </event>
 
+    <event name="connector_name">
+      <description summary="advertise connector name of the corresponding output">
+        Sent immediately after creating the ivi_wm_screen object.
+      </description>
+      <arg name="process_name" type="string"/>
+    </event>
+
     <enum name="error">
        <entry name="no_layer" value="0"
               summary="the layer with given id does not exist"/>

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -1382,6 +1382,7 @@ controller_create_screen(struct wl_client *client,
         wl_list_insert(&iviscrn->resource_list, wl_resource_get_link(screen_resource));
 
         ivi_wm_screen_send_screen_id(screen_resource, iviscrn->id_screen);
+        ivi_wm_screen_send_connector_name(screen_resource, iviscrn->output->name);
     }
 }
 


### PR DESCRIPTION
With this Pull request, we are sending connector name of a ivi screen, e,g,: HDMI-A-1, LVDS1.
@eucan updated LayerManagerControl, so that we can see this information there too.