### PR TITLE
Fix memory leak of nativesurface

### DIFF
--- a/ivi-layermanagement-examples/simple-ivi-share/src/simple-ivi-share.c
+++ b/ivi-layermanagement-examples/simple-ivi-share/src/simple-ivi-share.c
@@ -245,6 +245,8 @@ handle_share_surface_state(void *data, struct ivi_share_surface *share_surface,
     case IVI_SHARE_SURFACE_SHARE_SURFACE_STATE_NOT_EXIST:
         fprintf(stderr, "Specified surface (ID:%d) does not exist\n",
                 window->share_buffer.share_surface_id);
+        ivi_share_surface_destroy(window->share_surface);
+        window->share_surface = NULL;
         break;
     case IVI_SHARE_SURFACE_SHARE_SURFACE_STATE_INVALID_SURFACE:
         fprintf(stderr, "Specified surface (ID:%d) is invalid\n",

--- a/weston-ivi-shell/src/ivi-share.c
+++ b/weston-ivi-shell/src/ivi-share.c
@@ -38,6 +38,7 @@ struct ivi_share_nativesurface_client_link
     bool firstSendConfigureComp;
     struct wl_list link;                         /* ivi_share_nativesurface link */
     struct ivi_share_nativesurface *parent;
+    bool empty;
 };
 
 struct shell_surface
@@ -83,6 +84,13 @@ share_surface_destroy(struct wl_client *client,
     if (NULL == client_link) {
         weston_log("share_surface does not have user data\n");
         return;
+    }
+
+    if (client_link->empty) {
+	if (client_link->parent) {
+	    free(client_link->parent);
+	    client_link->parent = NULL;
+	}
     }
 
     wl_resource_destroy(resource);
@@ -384,7 +392,7 @@ add_nativesurface_client(struct ivi_share_nativesurface *nativesurface,
     link->client = client;
     link->firstSendConfigureComp = false;
     link->parent = nativesurface;
-
+    link->empty = (nativesurface->surface == NULL) ? true : false;
     wl_resource_set_implementation(link->resource, &share_surface_implementation,
                                    link, destroy_client_link);
     wl_list_insert(&nativesurface->client_list, &link->link);


### PR DESCRIPTION
Dear sir,

I found the memory leak in ivi-share.
When the original surface does not exist, empty nativesurface is created,
so alloc_share_nativesurface() allocates memory and stores the pointer to 'nativesurface'.
But it was not freed. So, I add the destroy code in share_surface_destroy() for freeing this memory when the state of share surface is not exist.

Thank you

Best regards,
Changwoo Cho