### PR TITLE
Make ivi-input-controller dependent on ivi-controller

### DIFF
--- a/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
+++ b/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
@@ -1362,8 +1362,8 @@ create_input_context(struct ivishell *shell)
     ctx->surface_destroyed.notify = handle_surface_destroy;
     ctx->compositor_destroy_listener.notify = input_controller_destroy;
 
-    ctx->ivishell->interface->add_listener_create_surface(&ctx->surface_created);
-    ctx->ivishell->interface->add_listener_remove_surface(&ctx->surface_destroyed);
+    wl_signal_add(&ctx->ivishell->ivisurface_created_signal, &ctx->surface_created);
+    wl_signal_add(&ctx->ivishell->ivisurface_removed_signal, &ctx->surface_destroyed);
     wl_signal_add(&ctx->ivishell->compositor->destroy_signal, &ctx->compositor_destroy_listener);
 
     ctx->seat_create_listener.notify = &handle_seat_create;

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -36,8 +36,8 @@
 #include <sys/mman.h>
 
 #include <weston.h>
-#include <weston/ivi-layout-export.h>
 #include "ivi-wm-server-protocol.h"
+#include "ivi-controller.h"
 
 #include "wayland-util.h"
 #ifdef IVI_SHARE_ENABLE
@@ -51,20 +51,6 @@ struct notification {
     struct wl_list link;
     struct wl_resource *resource;
     struct wl_list layout_link;
-};
-
-struct ivisurface {
-    struct wl_list link;
-    struct ivishell *shell;
-    uint32_t update_count;
-    struct ivi_layout_surface *layout_surface;
-    const struct ivi_layout_surface_properties *prop;
-    struct wl_listener property_changed;
-    struct wl_listener surface_destroy_listener;
-    struct wl_listener committed;
-    struct wl_list notification_list;
-    enum ivi_wm_surface_type type;
-    uint32_t frame_count;
 };
 
 struct ivilayer {
@@ -93,32 +79,6 @@ struct ivicontroller {
 
     struct wl_list layer_notifications;
     struct wl_list surface_notifications;
-};
-
-struct ivishell {
-    struct weston_compositor *compositor;
-    const struct ivi_layout_interface *interface;
-
-    struct wl_list list_surface;
-    struct wl_list list_layer;
-    struct wl_list list_screen;
-
-    struct wl_list list_controller;
-
-    struct wl_listener surface_created;
-    struct wl_listener surface_removed;
-    struct wl_listener surface_configured;
-
-    struct wl_listener layer_created;
-    struct wl_listener layer_removed;
-
-    struct wl_listener output_created;
-    struct wl_listener output_destroyed;
-
-    struct wl_listener destroy_listener;
-
-    struct wl_array screen_ids;
-    uint32_t screen_id_offset;
 };
 
 struct screenshot_frame_listener {

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -1648,6 +1648,8 @@ surface_event_create(struct wl_listener *listener, void *data)
         weston_log("failed to create surface");
         return;
     }
+
+    wl_signal_emit(&shell->ivisurface_created_signal, ivisurf);
 }
 
 static void
@@ -1668,6 +1670,7 @@ surface_event_remove(struct wl_listener *listener, void *data)
         return;
     }
 
+    wl_signal_emit(&shell->ivisurface_removed_signal, ivisurf);
     wl_list_for_each_safe(not, next, &ivisurf->notification_list, layout_link)
     {
         wl_list_remove(&not->link);
@@ -1952,6 +1955,9 @@ init_ivi_shell(struct weston_compositor *ec, struct ivishell *shell)
 
     shell->destroy_listener.notify = ivi_shell_destroy;
     wl_signal_add(&ec->destroy_signal, &shell->destroy_listener);
+
+    wl_signal_init(&shell->ivisurface_created_signal);
+    wl_signal_init(&shell->ivisurface_removed_signal);
 }
 
 int

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -1967,17 +1967,13 @@ setup_ivi_controller_server(struct weston_compositor *compositor,
 }
 
 static int
-load_input_module(struct weston_compositor *ec,
-                  const struct ivi_layout_interface *interface,
-                  size_t interface_version)
+load_input_module(struct ivishell *shell)
 {
-    struct weston_config *config = wet_get_config(ec);
+    struct weston_config *config = wet_get_config(shell->compositor);
     struct weston_config_section *section;
     char *input_module = NULL;
 
-    int (*input_module_init)(struct weston_compositor *ec,
-                             const struct ivi_layout_interface *interface,
-                             size_t interface_version);
+    int (*input_module_init)(struct ivishell *shell);
 
     section = weston_config_get_section(config, "ivi-shell", NULL, NULL);
 
@@ -1992,9 +1988,8 @@ load_input_module(struct weston_compositor *ec,
     if (!input_module_init)
         return -1;
 
-    if (input_module_init(ec, interface,
-                          sizeof(struct ivi_layout_interface)) != 0) {
-        weston_log("ivi-controller: Initialization of input module failes");
+    if (input_module_init(shell) != 0) {
+        weston_log("ivi-controller: Initialization of input module fails");
         return -1;
     }
 
@@ -2038,7 +2033,7 @@ controller_module_init(struct weston_compositor *compositor,
         return -1;
     }
 
-    if (load_input_module(compositor, interface, interface_version) < 0) {
+    if (load_input_module(shell) < 0) {
         destroy_screen_ids(shell);
         free(shell);
         return -1;

--- a/weston-ivi-shell/src/ivi-controller.h
+++ b/weston-ivi-shell/src/ivi-controller.h
@@ -51,6 +51,9 @@ struct ivishell {
 
     struct wl_list list_controller;
 
+    struct wl_signal ivisurface_created_signal;
+    struct wl_signal ivisurface_removed_signal;
+
     struct wl_listener surface_created;
     struct wl_listener surface_removed;
     struct wl_listener surface_configured;

--- a/weston-ivi-shell/src/ivi-controller.h
+++ b/weston-ivi-shell/src/ivi-controller.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2017 Advanced Driver Information Technology Joint Venture GmbH
+ *
+ * Permission to use, copy, modify, distribute, and sell this software and
+ * its documentation for any purpose is hereby granted without fee, provided
+ * that the above copyright notice appear in all copies and that both that
+ * copyright notice and this permission notice appear in supporting
+ * documentation, and that the name of the copyright holders not be used in
+ * advertising or publicity pertaining to distribution of the software
+ * without specific, written prior permission.  The copyright holders make
+ * no representations about the suitability of this software for any
+ * purpose.  It is provided "as is" without express or implied warranty.
+ *
+ * THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+ * SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef WESTON_IVI_SHELL_SRC_IVI_CONTROLLER_H_
+#define WESTON_IVI_SHELL_SRC_IVI_CONTROLLER_H_
+
+#include "ivi-wm-server-protocol.h"
+#include <weston/ivi-layout-export.h>
+
+struct ivisurface {
+    struct wl_list link;
+    struct ivishell *shell;
+    uint32_t update_count;
+    struct ivi_layout_surface *layout_surface;
+    const struct ivi_layout_surface_properties *prop;
+    struct wl_listener property_changed;
+    struct wl_listener surface_destroy_listener;
+    struct wl_listener committed;
+    struct wl_list notification_list;
+    enum ivi_wm_surface_type type;
+    uint32_t frame_count;
+    struct wl_list accepted_seat_list;
+};
+
+struct ivishell {
+    struct weston_compositor *compositor;
+    const struct ivi_layout_interface *interface;
+
+    struct wl_list list_surface;
+    struct wl_list list_layer;
+    struct wl_list list_screen;
+
+    struct wl_list list_controller;
+
+    struct wl_listener surface_created;
+    struct wl_listener surface_removed;
+    struct wl_listener surface_configured;
+
+    struct wl_listener layer_created;
+    struct wl_listener layer_removed;
+
+    struct wl_listener output_created;
+    struct wl_listener output_destroyed;
+
+    struct wl_listener destroy_listener;
+
+    struct wl_array screen_ids;
+    uint32_t screen_id_offset;
+};
+
+#endif /* WESTON_IVI_SHELL_SRC_IVI_CONTROLLER_H_ */


### PR DESCRIPTION
This PR is a preparation for xdg-shell support in ivi-shell in the future. ivi-input-controller is not registering for surface signals of ivi-layout anymore but for new surface signals introduced in ivi-controller. Therefore ivi-input-controller is now dependent on ivi-controller. Moreover ivi-input-controller now uses ivisurface and ivishell instead of dedicated structs, that just copies meta data.