### PR TITLE
protocol: install ivi-application.xml in sysroot

### DIFF
--- a/protocol/CMakeLists.txt
+++ b/protocol/CMakeLists.txt
@@ -170,6 +170,11 @@ install(
     DESTINATION include/ilm
 )
 
+install(
+    FILES ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+    DESTINATION share/wayland-protocols/stable/ivi-application
+)
+
 SET_TARGET_PROPERTIES(${PROJECT_NAME} PROPERTIES VERSION ${ILM_API_VERSION} SOVERSION ${ILM_API_VERSION})
 
 #=============================================================================================


### PR DESCRIPTION
so that it can be used by other components to
generate ivi-application-protocol.c and
ivi-application-client-protocol.h.

Signed-off-by: Emre Ucan <eucan@de.adit-jv.com>