### PR TITLE
Make ivi-input-controller dependent on ivi-controller

### DIFF
--- a/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
+++ b/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
@@ -1361,8 +1361,8 @@ create_input_context(struct ivishell *shell)
     ctx->surface_destroyed.notify = handle_surface_destroy;
     ctx->compositor_destroy_listener.notify = input_controller_destroy;
 
-    ctx->ivishell->interface->add_listener_create_surface(&ctx->surface_created);
-    ctx->ivishell->interface->add_listener_remove_surface(&ctx->surface_destroyed);
+    wl_signal_add(&ctx->ivishell->ivisurface_created_signal, &ctx->surface_created);
+    wl_signal_add(&ctx->ivishell->ivisurface_removed_signal, &ctx->surface_destroyed);
     wl_signal_add(&ctx->ivishell->compositor->destroy_signal, &ctx->compositor_destroy_listener);
 
     ctx->seat_create_listener.notify = &handle_seat_create;

--- a/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
+++ b/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
@@ -73,17 +73,15 @@ struct input_controller {
 };
 
 struct input_context {
-    struct wl_listener seat_create_listener;
     struct wl_list controller_list;
-    struct wl_list surface_list;
     struct wl_list seat_list;
-    struct weston_compositor *compositor;
-    const struct ivi_layout_interface *ivi_layout_interface;
     int successful_init_stage;
+    struct ivishell *ivishell;
 
     struct wl_listener surface_created;
     struct wl_listener surface_destroyed;
     struct wl_listener compositor_destroy_listener;
+    struct wl_listener seat_create_listener;
 };
 
 enum kbd_events {
@@ -125,7 +123,7 @@ static int
 add_accepted_seat(struct ivisurface *surface, const char *seat)
 {
     const struct ivi_layout_interface *interface =
-        surface->input_context->ivi_layout_interface;
+        surface->shell->interface;
     struct seat_focus *st_focus;
     int ret = 0;
 
@@ -163,7 +161,7 @@ remove_accepted_seat(struct ivisurface *surface, const char *seat)
 {
     int ret = 0;
     const struct ivi_layout_interface *interface =
-            surface->input_context->ivi_layout_interface;
+            surface->shell->interface;
 
     struct seat_focus *st_focus = get_accepted_seat(surface, seat);
 
@@ -224,7 +222,7 @@ input_ctrl_get_surf_ctx(struct input_context *ctx,
 {
     struct ivisurface *surf_ctx = NULL;
     struct ivisurface *ret_ctx = NULL;
-    wl_list_for_each(surf_ctx, &ctx->surface_list, link) {
+    wl_list_for_each(surf_ctx, &ctx->ivishell->list_surface, link) {
         if (lyt_surf == surf_ctx->layout_surface) {
             ret_ctx = surf_ctx;
             break;
@@ -238,7 +236,7 @@ static struct ivisurface *
 input_ctrl_get_surf_ctx_from_id(struct input_context *ctx,
         uint32_t ivi_surf_id)
 {
-    const struct ivi_layout_interface *interface = ctx->ivi_layout_interface;
+    const struct ivi_layout_interface *interface = ctx->ivishell->interface;
     struct ivi_layout_surface *lyt_surf;
     lyt_surf = interface->get_surface_from_id(ivi_surf_id);
 
@@ -253,7 +251,7 @@ input_ctrl_get_surf_ctx_from_surf(struct input_context *ctx,
     struct weston_surface *main_surface;
     struct ivi_layout_surface *layout_surf;
     struct ivisurface *surf_ctx = NULL;
-    const struct ivi_layout_interface *lyt_if = ctx->ivi_layout_interface;
+    const struct ivi_layout_interface *lyt_if = ctx->ivishell->interface;
     main_surface = weston_surface_get_main_surface(west_surf);
 
     if (NULL != main_surface) {
@@ -363,7 +361,7 @@ input_ctrl_kbd_leave_surf(struct seat_ctx *ctx_seat,
 {
     struct wl_keyboard_data kbd_data;
     struct input_context *ctx = ctx_seat->input_ctx;
-    const struct ivi_layout_interface *interface = ctx->ivi_layout_interface;
+    const struct ivi_layout_interface *interface = ctx->ivishell->interface;
     struct seat_focus *st_focus;
 
 
@@ -374,7 +372,7 @@ input_ctrl_kbd_leave_surf(struct seat_ctx *ctx_seat,
 
         kbd_data.kbd_evt = KEYBOARD_LEAVE;
         kbd_data.serial = wl_display_next_serial(
-                                ctx->compositor->wl_display);;
+                                ctx->ivishell->compositor->wl_display);;
         input_ctrl_kbd_wl_snd_event(ctx_seat, w_surf,
                 ctx_seat->keyboard_grab.keyboard, &kbd_data);
 
@@ -392,13 +390,13 @@ input_ctrl_kbd_enter_surf(struct seat_ctx *ctx_seat,
     struct wl_keyboard_data kbd_data;
     struct input_context *ctx = ctx_seat->input_ctx;
     struct seat_focus *st_focus;
-    const struct ivi_layout_interface *interface = ctx->ivi_layout_interface;
+    const struct ivi_layout_interface *interface = ctx->ivishell->interface;
     uint32_t serial;
 
     st_focus = get_accepted_seat(surf_ctx, ctx_seat->name_seat);
     if ((NULL != st_focus) &&
         (!(st_focus->focus & ILM_INPUT_DEVICE_KEYBOARD))) {
-        serial = wl_display_next_serial(ctx->compositor->wl_display);
+        serial = wl_display_next_serial(ctx->ivishell->compositor->wl_display);
 
         kbd_data.kbd_evt = KEYBOARD_ENTER;
         kbd_data.serial = serial;
@@ -419,7 +417,7 @@ input_ctrl_kbd_set_focus_surf(struct seat_ctx *ctx_seat,
 {
     struct input_context *ctx = ctx_seat->input_ctx;
     struct ivisurface *surf_ctx;
-    const struct ivi_layout_interface *interface = ctx->ivi_layout_interface;
+    const struct ivi_layout_interface *interface = ctx->ivishell->interface;
     struct weston_surface *w_surf;
 
     struct weston_keyboard *keyboard = weston_seat_get_keyboard(
@@ -449,7 +447,7 @@ keyboard_grab_key(struct weston_keyboard_grab *grab, uint32_t time,
     struct wl_keyboard_data kbd_data;
     struct weston_surface *surface;
     const struct ivi_layout_interface *interface =
-        seat_ctx->input_ctx->ivi_layout_interface;
+        seat_ctx->input_ctx->ivishell->interface;
 
     kbd_data.kbd_evt = KEYBOARD_KEY;
     kbd_data.time = time;
@@ -458,7 +456,7 @@ keyboard_grab_key(struct weston_keyboard_grab *grab, uint32_t time,
     kbd_data.serial = wl_display_next_serial(grab->keyboard->seat->
                                             compositor->wl_display);
 
-    wl_list_for_each(surf_ctx, &seat_ctx->input_ctx->surface_list, link) {
+    wl_list_for_each(surf_ctx, &seat_ctx->input_ctx->ivishell->list_surface, link) {
 
         st_focus = get_accepted_seat(surf_ctx, grab->keyboard->seat->seat_name);
         if (NULL == st_focus)
@@ -483,7 +481,7 @@ keyboard_grab_modifiers(struct weston_keyboard_grab *grab, uint32_t serial,
     struct weston_surface *surface;
     struct wl_keyboard_data kbd_data;
     const struct ivi_layout_interface *interface =
-        seat_ctx->input_ctx->ivi_layout_interface;
+        seat_ctx->input_ctx->ivishell->interface;
 
     kbd_data.kbd_evt = KEYBOARD_MODIFIER;
     kbd_data.serial = serial;
@@ -492,7 +490,7 @@ keyboard_grab_modifiers(struct weston_keyboard_grab *grab, uint32_t serial,
     kbd_data.mods_locked = mods_locked;
     kbd_data.group = group;
 
-    wl_list_for_each(surf_ctx, &seat_ctx->input_ctx->surface_list, link) {
+    wl_list_for_each(surf_ctx, &seat_ctx->input_ctx->ivishell->list_surface, link) {
 
         st_focus = get_accepted_seat(surf_ctx, grab->keyboard->seat->seat_name);
         if (NULL == st_focus)
@@ -526,7 +524,7 @@ input_ctrl_snd_focus_to_controller(struct ivisurface *surf_ctx,
         int32_t enabled)
 {
     struct input_context *ctx = ctx_seat->input_ctx;
-    const struct ivi_layout_interface *lyt_if = ctx->ivi_layout_interface;
+    const struct ivi_layout_interface *lyt_if = ctx->ivishell->interface;
     struct seat_focus *st_focus = NULL;
     uint32_t ivi_surf_id;
 
@@ -554,7 +552,7 @@ input_ctrl_ptr_leave_west_focus(struct seat_ctx *ctx_seat,
 {
     struct ivisurface *surf_ctx;
     struct input_context *ctx = ctx_seat->input_ctx;
-    const struct ivi_layout_interface *lyt_if = ctx->ivi_layout_interface;
+    const struct ivi_layout_interface *lyt_if = ctx->ivishell->interface;
     struct seat_focus *st_focus;
 
     if (NULL != pointer->focus) {
@@ -683,9 +681,9 @@ pointer_grab_focus(struct weston_pointer_grab *grab)
     if (seat->forced_ptr_focus_surf > 0) {
         /*When we want to force pointer focus to
          * a certain surface*/
-        layout_surf = ctx->ivi_layout_interface->
+        layout_surf = ctx->ivishell->interface->
                             get_surface_from_id(seat->forced_ptr_focus_surf);
-        forced_west_surf = ctx->ivi_layout_interface->
+        forced_west_surf = ctx->ivishell->interface->
                             surface_get_weston_surface(layout_surf);
 
         if (seat->forced_surf_enabled == ILM_TRUE) {
@@ -857,7 +855,7 @@ touch_grab_up(struct weston_touch_grab *grab, uint32_t time, int touch_id)
     struct weston_touch *touch = grab->touch;
     struct ivisurface *surf_ctx;
     const struct ivi_layout_interface *interface =
-        seat->input_ctx->ivi_layout_interface;
+        seat->input_ctx->ivishell->interface;
 
     if (NULL != touch->focus) {
         if (touch->num_tp == 0) {
@@ -1021,7 +1019,7 @@ handle_surface_destroy(struct wl_listener *listener, void *data)
             wl_container_of(listener, ctx, surface_destroyed);
     int surface_removed = 0;
     const struct ivi_layout_interface *interface =
-        ctx->ivi_layout_interface;
+        ctx->ivishell->interface;
 
     struct ivisurface *surf = (struct ivisurface *) data;
 
@@ -1045,16 +1043,13 @@ handle_surface_create(struct wl_listener *listener, void *data)
             wl_container_of(listener, input_ctx, surface_created);
     struct ivisurface *ivisurface = (struct ivisurface *) data;
     const struct ivi_layout_interface *interface =
-        input_ctx->ivi_layout_interface;
+        input_ctx->ivishell->interface;
 
-    ivisurface->input_context = input_ctx;
     wl_list_init(&ivisurface->accepted_seat_list);
     add_accepted_seat(ivisurface, "default");
     send_input_acceptance(input_ctx,
                           interface->get_id_of_surface(ivisurface->layout_surface),
                           "default", ILM_TRUE);
-
-    wl_list_insert(&input_ctx->surface_list, &ivisurface->link);
 }
 
 static void
@@ -1075,7 +1070,7 @@ setup_input_focus(struct input_context *ctx, uint32_t surface,
     struct weston_seat *seat;
     struct weston_surface *w_surf;
     const struct ivi_layout_interface *interface =
-                            ctx->ivi_layout_interface;
+                            ctx->ivishell->interface;
     uint32_t caps;
     struct ivi_layout_surface *current_layout_surface;
     struct seat_focus *st_focus;
@@ -1129,7 +1124,7 @@ setup_input_acceptance(struct input_context *ctx,
     struct weston_surface *w_surf;
     int found_seat = 0;
     const struct ivi_layout_interface *interface =
-        ctx->ivi_layout_interface;
+        ctx->ivishell->interface;
     struct weston_pointer *pointer;
     struct weston_touch *touch;
     struct weston_keyboard *keyboard;
@@ -1222,7 +1217,7 @@ bind_ivi_input(struct wl_client *client, void *data,
     struct weston_seat *seat;
     struct ivisurface *ivisurface;
     const struct ivi_layout_interface *interface =
-        ctx->ivi_layout_interface;
+        ctx->ivishell->interface;
     struct seat_focus *st_focus;
     uint32_t ivi_surf_id;
 
@@ -1245,13 +1240,13 @@ bind_ivi_input(struct wl_client *client, void *data,
     wl_list_insert(&ctx->controller_list, &controller->link);
 
     /* Send seat events for all known seats to the client */
-    wl_list_for_each(seat, &ctx->compositor->seat_list, link) {
+    wl_list_for_each(seat, &ctx->ivishell->compositor->seat_list, link) {
         ivi_input_send_seat_created(controller->resource,
                                                seat->seat_name,
                                                get_seat_capabilities(seat));
     }
     /* Send focus events for all known surfaces to the client */
-    wl_list_for_each(ivisurface, &ctx->surface_list, link) {
+    wl_list_for_each(ivisurface, &ctx->ivishell->list_surface, link) {
         ivi_surf_id = interface->get_id_of_surface(ivisurface->layout_surface);
         wl_list_for_each(st_focus, &ivisurface->accepted_seat_list, link) {
             ivi_input_send_input_focus(controller->resource,
@@ -1259,7 +1254,7 @@ bind_ivi_input(struct wl_client *client, void *data,
         }
     }
     /* Send acceptance events for all known surfaces to the client */
-    wl_list_for_each(ivisurface, &ctx->surface_list, link) {
+    wl_list_for_each(ivisurface, &ctx->ivishell->list_surface, link) {
         ivi_surf_id = interface->get_id_of_surface(ivisurface->layout_surface);
         wl_list_for_each(st_focus, &ivisurface->accepted_seat_list, link) {
             ivi_input_send_input_acceptance(controller->resource,
@@ -1288,7 +1283,7 @@ destroy_input_context(struct input_context *ctx)
     }
 
     wl_list_for_each_safe(surf_ctx, tmp_surf_ctx,
-            &ctx->surface_list, link) {
+            &ctx->ivishell->list_surface, link) {
 
         input_ctrl_free_surf_ctx(surf_ctx);
     }
@@ -1346,8 +1341,7 @@ input_controller_destroy(struct wl_listener *listener, void *data)
 
 
 static struct input_context *
-create_input_context(struct weston_compositor *ec,
-                     const struct ivi_layout_interface *interface)
+create_input_context(struct ivishell *shell)
 {
     struct input_context *ctx = NULL;
     struct weston_seat *seat;
@@ -1358,10 +1352,8 @@ create_input_context(struct weston_compositor *ec,
         return NULL;
     }
 
-    ctx->compositor = ec;
-    ctx->ivi_layout_interface = interface;
+    ctx->ivishell = shell;
     wl_list_init(&ctx->controller_list);
-    wl_list_init(&ctx->surface_list);
     wl_list_init(&ctx->seat_list);
 
     /* Add signal handlers for ivi surfaces. */
@@ -1369,14 +1361,14 @@ create_input_context(struct weston_compositor *ec,
     ctx->surface_destroyed.notify = handle_surface_destroy;
     ctx->compositor_destroy_listener.notify = input_controller_destroy;
 
-    interface->add_listener_create_surface(&ctx->surface_created);
-    interface->add_listener_remove_surface(&ctx->surface_destroyed);
-    wl_signal_add(&ec->destroy_signal, &ctx->compositor_destroy_listener);
+    ctx->ivishell->interface->add_listener_create_surface(&ctx->surface_created);
+    ctx->ivishell->interface->add_listener_remove_surface(&ctx->surface_destroyed);
+    wl_signal_add(&ctx->ivishell->compositor->destroy_signal, &ctx->compositor_destroy_listener);
 
     ctx->seat_create_listener.notify = &handle_seat_create;
-    wl_signal_add(&ec->seat_created_signal, &ctx->seat_create_listener);
+    wl_signal_add(&ctx->ivishell->compositor->seat_created_signal, &ctx->seat_create_listener);
 
-    wl_list_for_each(seat, &ec->seat_list, link) {
+    wl_list_for_each(seat, &ctx->ivishell->compositor->seat_list, link) {
         handle_seat_create(&ctx->seat_create_listener, seat);
         wl_signal_emit(&seat->updated_caps_signal, seat);
     }
@@ -1386,8 +1378,7 @@ create_input_context(struct weston_compositor *ec,
 
 
 static int
-input_controller_init(struct weston_compositor *ec,
-		const struct ivi_layout_interface *layout_if)
+input_controller_init(struct ivishell *shell)
 {
     int successful_init_stage = 0;
     int init_stage;
@@ -1400,12 +1391,12 @@ input_controller_init(struct weston_compositor *ec,
         switch(init_stage)
         {
         case 0:
-            ctx = create_input_context(ec, layout_if);
+            ctx = create_input_context(shell);
             if (NULL != ctx)
                 successful_init_stage++;
             break;
         case 1:
-            if (wl_global_create(ec->wl_display, &ivi_input_interface, 1,
+            if (wl_global_create(shell->compositor->wl_display, &ivi_input_interface, 1,
                                  ctx, bind_ivi_input) != NULL) {
                 successful_init_stage++;
             }
@@ -1430,14 +1421,12 @@ input_controller_init(struct weston_compositor *ec,
 }
 
 WL_EXPORT int
-input_controller_module_init(struct weston_compositor *ec,
-                             const struct ivi_layout_interface *interface,
-                             size_t interface_version)
+input_controller_module_init(struct ivishell *shell)
 {
     int ret = -1;
 
-    if (NULL != interface) {
-        ret = input_controller_init(ec, interface);
+    if (NULL != shell->interface) {
+        ret = input_controller_init(shell);
 
         if (ret >= 0)
             weston_log("ivi-input-controller module loaded successfully!\n");

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -36,8 +36,8 @@
 #include <sys/mman.h>
 
 #include <weston.h>
-#include <weston/ivi-layout-export.h>
 #include "ivi-wm-server-protocol.h"
+#include "ivi-controller.h"
 
 #include "wayland-util.h"
 #ifdef IVI_SHARE_ENABLE
@@ -51,20 +51,6 @@ struct notification {
     struct wl_list link;
     struct wl_resource *resource;
     struct wl_list layout_link;
-};
-
-struct ivisurface {
-    struct wl_list link;
-    struct ivishell *shell;
-    uint32_t update_count;
-    struct ivi_layout_surface *layout_surface;
-    const struct ivi_layout_surface_properties *prop;
-    struct wl_listener property_changed;
-    struct wl_listener surface_destroy_listener;
-    struct wl_listener committed;
-    struct wl_list notification_list;
-    enum ivi_wm_surface_type type;
-    uint32_t frame_count;
 };
 
 struct ivilayer {
@@ -93,32 +79,6 @@ struct ivicontroller {
 
     struct wl_list layer_notifications;
     struct wl_list surface_notifications;
-};
-
-struct ivishell {
-    struct weston_compositor *compositor;
-    const struct ivi_layout_interface *interface;
-
-    struct wl_list list_surface;
-    struct wl_list list_layer;
-    struct wl_list list_screen;
-
-    struct wl_list list_controller;
-
-    struct wl_listener surface_created;
-    struct wl_listener surface_removed;
-    struct wl_listener surface_configured;
-
-    struct wl_listener layer_created;
-    struct wl_listener layer_removed;
-
-    struct wl_listener output_created;
-    struct wl_listener output_destroyed;
-
-    struct wl_listener destroy_listener;
-
-    struct wl_array screen_ids;
-    uint32_t screen_id_offset;
 };
 
 struct screenshot_frame_listener {

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -1648,6 +1648,8 @@ surface_event_create(struct wl_listener *listener, void *data)
         weston_log("failed to create surface");
         return;
     }
+
+    wl_signal_emit(&shell->ivisurface_created_signal, ivisurf);
 }
 
 static void
@@ -1668,6 +1670,7 @@ surface_event_remove(struct wl_listener *listener, void *data)
         return;
     }
 
+    wl_signal_emit(&shell->ivisurface_removed_signal, ivisurf);
     wl_list_for_each_safe(not, next, &ivisurf->notification_list, layout_link)
     {
         wl_list_remove(&not->link);
@@ -1952,6 +1955,9 @@ init_ivi_shell(struct weston_compositor *ec, struct ivishell *shell)
 
     shell->destroy_listener.notify = ivi_shell_destroy;
     wl_signal_add(&ec->destroy_signal, &shell->destroy_listener);
+
+    wl_signal_init(&shell->ivisurface_created_signal);
+    wl_signal_init(&shell->ivisurface_removed_signal);
 }
 
 int

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -1967,17 +1967,13 @@ setup_ivi_controller_server(struct weston_compositor *compositor,
 }
 
 static int
-load_input_module(struct weston_compositor *ec,
-                  const struct ivi_layout_interface *interface,
-                  size_t interface_version)
+load_input_module(struct ivishell *shell)
 {
-    struct weston_config *config = wet_get_config(ec);
+    struct weston_config *config = wet_get_config(shell->compositor);
     struct weston_config_section *section;
     char *input_module = NULL;
 
-    int (*input_module_init)(struct weston_compositor *ec,
-                             const struct ivi_layout_interface *interface,
-                             size_t interface_version);
+    int (*input_module_init)(struct ivishell *shell);
 
     section = weston_config_get_section(config, "ivi-shell", NULL, NULL);
 
@@ -1992,9 +1988,8 @@ load_input_module(struct weston_compositor *ec,
     if (!input_module_init)
         return -1;
 
-    if (input_module_init(ec, interface,
-                          sizeof(struct ivi_layout_interface)) != 0) {
-        weston_log("ivi-controller: Initialization of input module failes");
+    if (input_module_init(shell) != 0) {
+        weston_log("ivi-controller: Initialization of input module fails");
         return -1;
     }
 
@@ -2038,7 +2033,7 @@ controller_module_init(struct weston_compositor *compositor,
         return -1;
     }
 
-    if (load_input_module(compositor, interface, interface_version) < 0) {
+    if (load_input_module(shell) < 0) {
         destroy_screen_ids(shell);
         free(shell);
         return -1;

--- a/weston-ivi-shell/src/ivi-controller.h
+++ b/weston-ivi-shell/src/ivi-controller.h
@@ -51,6 +51,9 @@ struct ivishell {
 
     struct wl_list list_controller;
 
+    struct wl_signal ivisurface_created_signal;
+    struct wl_signal ivisurface_removed_signal;
+
     struct wl_listener surface_created;
     struct wl_listener surface_removed;
     struct wl_listener surface_configured;

--- a/weston-ivi-shell/src/ivi-controller.h
+++ b/weston-ivi-shell/src/ivi-controller.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2017 Advanced Driver Information Technology Joint Venture GmbH
+ *
+ * Permission to use, copy, modify, distribute, and sell this software and
+ * its documentation for any purpose is hereby granted without fee, provided
+ * that the above copyright notice appear in all copies and that both that
+ * copyright notice and this permission notice appear in supporting
+ * documentation, and that the name of the copyright holders not be used in
+ * advertising or publicity pertaining to distribution of the software
+ * without specific, written prior permission.  The copyright holders make
+ * no representations about the suitability of this software for any
+ * purpose.  It is provided "as is" without express or implied warranty.
+ *
+ * THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+ * SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef WESTON_IVI_SHELL_SRC_IVI_CONTROLLER_H_
+#define WESTON_IVI_SHELL_SRC_IVI_CONTROLLER_H_
+
+#include "ivi-wm-server-protocol.h"
+#include <weston/ivi-layout-export.h>
+
+struct ivisurface {
+    struct wl_list link;
+    struct ivishell *shell;
+    uint32_t update_count;
+    struct ivi_layout_surface *layout_surface;
+    const struct ivi_layout_surface_properties *prop;
+    struct wl_listener property_changed;
+    struct wl_listener surface_destroy_listener;
+    struct wl_listener committed;
+    struct wl_list notification_list;
+    enum ivi_wm_surface_type type;
+    uint32_t frame_count;
+    struct wl_list accepted_seat_list;
+};
+
+struct ivishell {
+    struct weston_compositor *compositor;
+    const struct ivi_layout_interface *interface;
+
+    struct wl_list list_surface;
+    struct wl_list list_layer;
+    struct wl_list list_screen;
+
+    struct wl_list list_controller;
+
+    struct wl_listener surface_created;
+    struct wl_listener surface_removed;
+    struct wl_listener surface_configured;
+
+    struct wl_listener layer_created;
+    struct wl_listener layer_removed;
+
+    struct wl_listener output_created;
+    struct wl_listener output_destroyed;
+
+    struct wl_listener destroy_listener;
+
+    struct wl_array screen_ids;
+    uint32_t screen_id_offset;
+};
+
+#endif /* WESTON_IVI_SHELL_SRC_IVI_CONTROLLER_H_ */


### PR DESCRIPTION
This PR is a preparation for xdg-shell support in ivi-shell in the future. ivi-input-controller is not registering for surface signals of ivi-layout anymore but for new surface signals introduced in ivi-controller. Therefore ivi-input-controller is now dependent on ivi-controller. Moreover ivi-input-controller now uses ivisurface and ivishell instead of dedicated structs, that just copies meta data.