### PR TITLE
Preparation for id generation for xdg-shell application support in ivi-shell

### DIFF
--- a/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
+++ b/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
@@ -122,8 +122,6 @@ get_accepted_seat(struct ivisurface *surface, const char *seat)
 static int
 add_accepted_seat(struct ivisurface *surface, const char *seat)
 {
-    const struct ivi_layout_interface *interface =
-        surface->shell->interface;
     struct seat_focus *st_focus;
     int ret = 0;
 
@@ -160,8 +158,6 @@ static int
 remove_accepted_seat(struct ivisurface *surface, const char *seat)
 {
     int ret = 0;
-    const struct ivi_layout_interface *interface =
-            surface->shell->interface;
 
     struct seat_focus *st_focus = get_accepted_seat(surface, seat);
 
@@ -361,7 +357,6 @@ input_ctrl_kbd_leave_surf(struct seat_ctx *ctx_seat,
 {
     struct wl_keyboard_data kbd_data;
     struct input_context *ctx = ctx_seat->input_ctx;
-    const struct ivi_layout_interface *interface = ctx->ivishell->interface;
     struct seat_focus *st_focus;
 
 
@@ -390,7 +385,6 @@ input_ctrl_kbd_enter_surf(struct seat_ctx *ctx_seat,
     struct wl_keyboard_data kbd_data;
     struct input_context *ctx = ctx_seat->input_ctx;
     struct seat_focus *st_focus;
-    const struct ivi_layout_interface *interface = ctx->ivishell->interface;
     uint32_t serial;
 
     st_focus = get_accepted_seat(surf_ctx, ctx_seat->name_seat);
@@ -524,7 +518,6 @@ input_ctrl_snd_focus_to_controller(struct ivisurface *surf_ctx,
         int32_t enabled)
 {
     struct input_context *ctx = ctx_seat->input_ctx;
-    const struct ivi_layout_interface *lyt_if = ctx->ivishell->interface;
     struct seat_focus *st_focus = NULL;
     uint32_t ivi_surf_id;
 
@@ -552,7 +545,6 @@ input_ctrl_ptr_leave_west_focus(struct seat_ctx *ctx_seat,
 {
     struct ivisurface *surf_ctx;
     struct input_context *ctx = ctx_seat->input_ctx;
-    const struct ivi_layout_interface *lyt_if = ctx->ivishell->interface;
     struct seat_focus *st_focus;
 
     if (NULL != pointer->focus) {
@@ -854,8 +846,6 @@ touch_grab_up(struct weston_touch_grab *grab, uint32_t time, int touch_id)
     struct seat_focus *st_focus;
     struct weston_touch *touch = grab->touch;
     struct ivisurface *surf_ctx;
-    const struct ivi_layout_interface *interface =
-        seat->input_ctx->ivishell->interface;
 
     if (NULL != touch->focus) {
         if (touch->num_tp == 0) {
@@ -1018,8 +1008,6 @@ handle_surface_destroy(struct wl_listener *listener, void *data)
     struct input_context *ctx =
             wl_container_of(listener, ctx, surface_destroyed);
     int surface_removed = 0;
-    const struct ivi_layout_interface *interface =
-        ctx->ivishell->interface;
 
     struct ivisurface *surf = (struct ivisurface *) data;
 
@@ -1042,8 +1030,6 @@ handle_surface_create(struct wl_listener *listener, void *data)
     struct input_context *input_ctx =
             wl_container_of(listener, input_ctx, surface_created);
     struct ivisurface *ivisurface = (struct ivisurface *) data;
-    const struct ivi_layout_interface *interface =
-        input_ctx->ivishell->interface;
 
     wl_list_init(&ivisurface->accepted_seat_list);
     add_accepted_seat(ivisurface, "default");
@@ -1216,8 +1202,6 @@ bind_ivi_input(struct wl_client *client, void *data,
     struct input_controller *controller;
     struct weston_seat *seat;
     struct ivisurface *ivisurface;
-    const struct ivi_layout_interface *interface =
-        ctx->ivishell->interface;
     struct seat_focus *st_focus;
     uint32_t ivi_surf_id;
 

--- a/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
+++ b/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
@@ -140,16 +140,16 @@ add_accepted_seat(struct ivisurface *surface, const char *seat)
             } else {
                 free(st_focus);
                 weston_log("%s Failed to allocate memory for seat addition of surface %d",
-                        __FUNCTION__, interface->get_id_of_surface(surface->layout_surface));
+                        __FUNCTION__, surface->surface_id);
             }
        } else {
             weston_log("%s Failed to allocate memory for seat addition of surface %d",
-                    __FUNCTION__, interface->get_id_of_surface(surface->layout_surface));
+                    __FUNCTION__, surface->surface_id);
         }
     } else {
         weston_log("%s: Warning: seat '%s' is already accepted by surface %d\n",
                    __FUNCTION__, seat,
-                   interface->get_id_of_surface(surface->layout_surface));
+                   surface->surface_id);
         ret = 1;
     }
 
@@ -174,7 +174,7 @@ remove_accepted_seat(struct ivisurface *surface, const char *seat)
     } else {
         weston_log("%s: Warning: seat '%s' not found for surface %u\n",
                   __FUNCTION__, seat,
-                  interface->get_id_of_surface(surface->layout_surface));
+                  surface->surface_id);
     }
     return ret;
 }
@@ -378,7 +378,7 @@ input_ctrl_kbd_leave_surf(struct seat_ctx *ctx_seat,
 
         st_focus->focus &= ~ILM_INPUT_DEVICE_KEYBOARD;
         send_input_focus(ctx,
-                interface->get_id_of_surface(surf_ctx->layout_surface),
+                surf_ctx->surface_id,
                 ILM_INPUT_DEVICE_KEYBOARD, ILM_FALSE);
     }
 }
@@ -405,7 +405,7 @@ input_ctrl_kbd_enter_surf(struct seat_ctx *ctx_seat,
 
         st_focus->focus |= ILM_INPUT_DEVICE_KEYBOARD;
         send_input_focus(ctx,
-                interface->get_id_of_surface(surf_ctx->layout_surface),
+                surf_ctx->surface_id,
                 ILM_INPUT_DEVICE_KEYBOARD, ILM_TRUE);
 
     }
@@ -529,7 +529,7 @@ input_ctrl_snd_focus_to_controller(struct ivisurface *surf_ctx,
     uint32_t ivi_surf_id;
 
     if (NULL != surf_ctx) {
-        ivi_surf_id = lyt_if->get_id_of_surface(surf_ctx->layout_surface);
+        ivi_surf_id = surf_ctx->surface_id;
 
         st_focus = get_accepted_seat(surf_ctx, ctx_seat->name_seat);
         /* Send focus lost event to the surface which has lost the focus*/
@@ -1032,7 +1032,7 @@ handle_surface_destroy(struct wl_listener *listener, void *data)
 
     if (!surface_removed) {
         weston_log("%s: Warning! surface %d already destroyed\n", __FUNCTION__,
-                   interface->get_id_of_surface((surf->layout_surface)));
+                   surf->surface_id);
     }
 }
 
@@ -1048,7 +1048,7 @@ handle_surface_create(struct wl_listener *listener, void *data)
     wl_list_init(&ivisurface->accepted_seat_list);
     add_accepted_seat(ivisurface, "default");
     send_input_acceptance(input_ctx,
-                          interface->get_id_of_surface(ivisurface->layout_surface),
+                          ivisurface->surface_id,
                           "default", ILM_TRUE);
 }
 
@@ -1247,7 +1247,7 @@ bind_ivi_input(struct wl_client *client, void *data,
     }
     /* Send focus events for all known surfaces to the client */
     wl_list_for_each(ivisurface, &ctx->ivishell->list_surface, link) {
-        ivi_surf_id = interface->get_id_of_surface(ivisurface->layout_surface);
+        ivi_surf_id = ivisurface->surface_id;
         wl_list_for_each(st_focus, &ivisurface->accepted_seat_list, link) {
             ivi_input_send_input_focus(controller->resource,
                                 ivi_surf_id, st_focus->focus, ILM_TRUE);
@@ -1255,7 +1255,7 @@ bind_ivi_input(struct wl_client *client, void *data,
     }
     /* Send acceptance events for all known surfaces to the client */
     wl_list_for_each(ivisurface, &ctx->ivishell->list_surface, link) {
-        ivi_surf_id = interface->get_id_of_surface(ivisurface->layout_surface);
+        ivi_surf_id = ivisurface->surface_id;
         wl_list_for_each(st_focus, &ivisurface->accepted_seat_list, link) {
             ivi_input_send_input_acceptance(controller->resource,
                                 ivi_surf_id, st_focus->seat_name, ILM_TRUE);

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -124,6 +124,20 @@ unbind_resource_controller(struct wl_resource *resource)
     controller = NULL;
 }
 
+static struct ivi_layout_surface *
+get_layout_surface_from_id(struct wl_list *list_surf, uint32_t surface_id)
+{
+    struct ivisurface *ivisurf = NULL;
+
+    wl_list_for_each(ivisurf, list_surf, link) {
+        if (ivisurf->surface_id == surface_id) {
+            return ivisurf->layout_surface;
+        }
+    }
+
+    return NULL;
+}
+
 static struct ivisurface*
 get_surface(struct wl_list *list_surf, struct ivi_layout_surface *layout_surface)
 {
@@ -281,7 +295,7 @@ controller_set_surface_opacity(struct wl_client *client,
     (void)client;
     struct ivi_layout_surface *layout_surface;
 
-    layout_surface = lyt->get_surface_from_id(surface_id);
+    layout_surface = get_layout_surface_from_id(&ctrl->shell->list_surface, surface_id);
     if (!layout_surface) {
         ivi_wm_send_surface_error(resource, surface_id,
                                   IVI_WM_SURFACE_ERROR_NO_SURFACE,
@@ -307,7 +321,7 @@ controller_set_surface_source_rectangle(struct wl_client *client,
     struct ivi_layout_surface *layout_surface;
     const struct ivi_layout_surface_properties *prop;
 
-    layout_surface = lyt->get_surface_from_id(surface_id);
+    layout_surface = get_layout_surface_from_id(&ctrl->shell->list_surface, surface_id);
     if (!layout_surface) {
         ivi_wm_send_surface_error(resource, surface_id,
                                   IVI_WM_SURFACE_ERROR_NO_SURFACE,
@@ -345,7 +359,7 @@ controller_set_surface_destination_rectangle(struct wl_client *client,
     struct ivi_layout_surface *layout_surface;
     const struct ivi_layout_surface_properties *prop;
 
-    layout_surface = lyt->get_surface_from_id(surface_id);
+    layout_surface = get_layout_surface_from_id(&ctrl->shell->list_surface, surface_id);
     if (!layout_surface) {
         ivi_wm_send_surface_error(resource, surface_id,
                                   IVI_WM_SURFACE_ERROR_NO_SURFACE,
@@ -385,7 +399,7 @@ controller_set_surface_visibility(struct wl_client *client,
     (void)client;
     struct ivi_layout_surface *layout_surface;
 
-    layout_surface = lyt->get_surface_from_id(surface_id);
+    layout_surface = get_layout_surface_from_id(&ctrl->shell->list_surface, surface_id);
     if (!layout_surface) {
         ivi_wm_send_surface_error(resource, surface_id,
                                   IVI_WM_SURFACE_ERROR_NO_SURFACE,
@@ -466,7 +480,7 @@ controller_surface_screenshot(struct wl_client *client,
         return;
     }
 
-    layout_surface = lyt->get_surface_from_id(surface_id);
+    layout_surface = get_layout_surface_from_id(&ctrl->shell->list_surface, surface_id);
     if (!layout_surface) {
         ivi_screenshot_send_error(
             screenshot, IVI_SCREENSHOT_ERROR_NO_SURFACE,
@@ -571,7 +585,7 @@ controller_surface_sync(struct wl_client *client,
     (void)client;
     struct notification *not;
 
-    layout_surface = lyt->get_surface_from_id(surface_id);
+    layout_surface = get_layout_surface_from_id(&ctrl->shell->list_surface, surface_id);
     if (!layout_surface) {
         ivi_wm_send_surface_error(resource, surface_id,
                                   IVI_WM_SURFACE_ERROR_NO_SURFACE,
@@ -622,7 +636,7 @@ controller_set_surface_type(struct wl_client *client, struct wl_resource *resour
     struct ivi_layout_surface *layout_surface;
     struct ivisurface *ivisurf;
 
-    layout_surface = lyt->get_surface_from_id(surface_id);
+    layout_surface = get_layout_surface_from_id(&ctrl->shell->list_surface, surface_id);
     if (!layout_surface) {
         ivi_wm_send_surface_error(resource, surface_id,
                                   IVI_WM_SURFACE_ERROR_NO_SURFACE,
@@ -668,7 +682,7 @@ controller_surface_get(struct wl_client *client, struct wl_resource *resource,
 
     mask = convert_protocol_enum(param);
 
-    layout_surface = lyt->get_surface_from_id(surface_id);
+    layout_surface = get_layout_surface_from_id(&ctrl->shell->list_surface, surface_id);
     if (!layout_surface) {
         ivi_wm_send_surface_error(resource, surface_id,
                                   IVI_WM_SURFACE_ERROR_NO_SURFACE,
@@ -843,7 +857,7 @@ controller_layer_add_surface(struct wl_client *client,
         return;
     }
 
-    layout_surface = lyt->get_surface_from_id(surface_id);
+    layout_surface = get_layout_surface_from_id(&ctrl->shell->list_surface, surface_id);
     if (!layout_surface) {
         ivi_wm_send_layer_error(resource, surface_id,
                                 IVI_WM_LAYER_ERROR_NO_SURFACE,
@@ -874,7 +888,7 @@ controller_layer_remove_surface(struct wl_client *client,
         return;
     }
 
-    layout_surface = lyt->get_surface_from_id(surface_id);
+    layout_surface = get_layout_surface_from_id(&ctrl->shell->list_surface, surface_id);
     if (!layout_surface) {
         ivi_wm_send_layer_error(resource, surface_id,
                                 IVI_WM_LAYER_ERROR_NO_SURFACE,

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -1645,20 +1645,22 @@ surface_event_create(struct wl_listener *listener, void *data)
 {
     struct ivishell *shell = wl_container_of(listener, shell, surface_created);
     const struct ivi_layout_interface *lyt = shell->interface;
-    struct ivisurface *ivisurf = NULL;
     struct ivi_layout_surface *layout_surface =
            (struct ivi_layout_surface *) data;
-    uint32_t surface_id = 0;
 
-    surface_id = lyt->get_id_of_surface(layout_surface);
+    uint32_t surface_id = lyt->get_id_of_surface(layout_surface);
 
-    ivisurf = create_surface(shell, layout_surface, surface_id);
-    if (ivisurf == NULL) {
-        weston_log("failed to create surface");
-        return;
+    if (surface_id != IVI_INVALID_ID)
+    {
+        struct ivisurface *ivisurf = NULL;
+        ivisurf = create_surface(shell, layout_surface, surface_id);
+        if (ivisurf == NULL) {
+            weston_log("failed to create surface");
+            return;
+        }
+
+        wl_signal_emit(&shell->ivisurface_created_signal, ivisurf);
     }
-
-    wl_signal_emit(&shell->ivisurface_created_signal, ivisurf);
 }
 
 static void
@@ -1750,7 +1752,8 @@ surface_event_configure(struct wl_listener *listener, void *data)
     uint32_t surface_id;
     surface_id = lyt->get_id_of_surface(layout_surface);
 
-    configure_surface(shell, layout_surface, surface_id);
+    if (surface_id != IVI_INVALID_ID)
+        configure_surface(shell, layout_surface, surface_id);
 }
 
 static int32_t
@@ -1813,9 +1816,10 @@ check_layout_surfaces(struct ivishell *shell)
 
     for (i = 0; i < length; i++) {
         surface_id = lyt->get_id_of_surface(pArray[i]);
-        ivisurf = create_surface(shell, pArray[i], surface_id);
-        if (ivisurf == NULL) {
-            weston_log("failed to create surface");
+        if(surface_id != IVI_INVALID_ID) {
+            ivisurf = create_surface(shell, pArray[i], surface_id);
+            if (ivisurf == NULL)
+                weston_log("failed to create surface");
         }
     }
 

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -160,7 +160,6 @@ send_surface_configure_event(struct ivicontroller * ctrl,
     struct weston_surface *surface;
     const struct ivi_layout_interface *lyt = ctrl->shell->interface;
 
-
     surface = lyt->surface_get_weston_surface(layout_surface);
 
     if (!surface)
@@ -216,7 +215,7 @@ send_surface_prop(struct wl_listener *listener, void *data)
 
     mask = ivisurf->prop->event_mask;
 
-    surface_id = lyt->get_id_of_surface(ivisurf->layout_surface);
+    surface_id = ivisurf->surface_id;
 
     wl_list_for_each(not, &ivisurf->notification_list, layout_link) {
         ctrl = wl_resource_get_user_data(not->resource);
@@ -989,8 +988,8 @@ controller_layer_get(struct wl_client *client, struct wl_resource *resource,
     const struct ivi_layout_layer_properties *prop;
     enum ivi_layout_notification_mask mask;
     struct ivi_layout_surface **surf_list = NULL;
+    struct ivisurface *ivisurf;
     int32_t surface_count, i;
-    uint32_t id;
 
     layout_layer = lyt->get_layer_from_id(layer_id);
     if (!layout_layer) {
@@ -1007,8 +1006,8 @@ controller_layer_get(struct wl_client *client, struct wl_resource *resource,
     if (param & IVI_WM_PARAM_RENDER_ORDER) {
         lyt->get_surfaces_on_layer(layout_layer, &surface_count, &surf_list);
         for (i = 0; i < surface_count; i++) {
-            id = lyt->get_id_of_surface(surf_list[i]);
-            ivi_wm_send_layer_surface_added(ctrl->resource, layer_id, id);
+            ivisurf = get_surface(&ctrl->shell->list_surface, surf_list[i]);
+            ivi_wm_send_layer_surface_added(ctrl->resource, layer_id, ivisurf->surface_id);
         }
 
         free(surf_list);
@@ -1413,7 +1412,7 @@ bind_ivi_controller(struct wl_client *client, void *data,
     wl_list_init(&controller->layer_notifications);
 
     wl_list_for_each_reverse(ivisurf, &shell->list_surface, link) {
-        surface_id = shell->interface->get_id_of_surface(ivisurf->layout_surface);
+        surface_id = ivisurf->surface_id;
         ivi_wm_send_surface_created(controller->resource, surface_id);
     }
 
@@ -1539,7 +1538,7 @@ surface_committed(struct wl_listener *listener, void *data)
 static struct ivisurface*
 create_surface(struct ivishell *shell,
                struct ivi_layout_surface *layout_surface,
-               uint32_t id_surface)
+               uint32_t surface_id)
 {
     const struct ivi_layout_interface *lyt = shell->interface;
     struct ivisurface *ivisurf = NULL;
@@ -1555,6 +1554,7 @@ create_surface(struct ivishell *shell,
     ivisurf->shell = shell;
     ivisurf->layout_surface = layout_surface;
     ivisurf->prop = lyt->get_properties_of_surface(layout_surface);
+    ivisurf->surface_id = surface_id;
     wl_list_insert(&shell->list_surface, &ivisurf->link);
     wl_list_init(&ivisurf->notification_list);
 
@@ -1564,7 +1564,7 @@ create_surface(struct ivishell *shell,
 
     wl_list_for_each(controller, &shell->list_controller, link) {
         if (controller->resource)
-            ivi_wm_send_surface_created(controller->resource, id_surface);
+            ivi_wm_send_surface_created(controller->resource, surface_id);
     }
 
      ivisurf->property_changed.notify = send_surface_prop;
@@ -1606,7 +1606,7 @@ layer_event_remove(struct wl_listener *listener, void *data)
 
     ivilayer = get_layer(&shell->list_layer, layout_layer);
     if (ivilayer == NULL) {
-        weston_log("id_surface is not created yet\n");
+        weston_log("surface_id is not created yet\n");
         return;
     }
 
@@ -1639,11 +1639,11 @@ surface_event_create(struct wl_listener *listener, void *data)
     struct ivisurface *ivisurf = NULL;
     struct ivi_layout_surface *layout_surface =
            (struct ivi_layout_surface *) data;
-    uint32_t id_surface = 0;
+    uint32_t surface_id = 0;
 
-    id_surface = lyt->get_id_of_surface(layout_surface);
+    surface_id = lyt->get_id_of_surface(layout_surface);
 
-    ivisurf = create_surface(shell, layout_surface, id_surface);
+    ivisurf = create_surface(shell, layout_surface, surface_id);
     if (ivisurf == NULL) {
         weston_log("failed to create surface");
         return;
@@ -1661,12 +1661,12 @@ surface_event_remove(struct wl_listener *listener, void *data)
     struct ivisurface *ivisurf = NULL;
     struct ivi_layout_surface *layout_surface =
            (struct ivi_layout_surface *) data;
-    uint32_t id_surface = 0;
+    uint32_t surface_id = 0;
     struct notification *not, *next;
 
     ivisurf = get_surface(&shell->list_surface, layout_surface);
     if (ivisurf == NULL) {
-        weston_log("id_surface is not created yet\n");
+        weston_log("surface_id is not created yet\n");
         return;
     }
 
@@ -1678,16 +1678,16 @@ surface_event_remove(struct wl_listener *listener, void *data)
         free(not);
     }
 
+    surface_id = ivisurf->surface_id;
+
     wl_list_remove(&ivisurf->link);
     wl_list_remove(&ivisurf->property_changed.link);
     wl_list_remove(&ivisurf->committed.link);
     free(ivisurf);
 
-    id_surface = shell->interface->get_id_of_surface(layout_surface);
-
     wl_list_for_each(controller, &shell->list_controller, link) {
         if (controller->resource)
-            ivi_wm_send_surface_destroyed(controller->resource, id_surface);
+            ivi_wm_send_surface_destroyed(controller->resource, surface_id);
     }
 }
 
@@ -1707,7 +1707,7 @@ surface_event_configure(struct wl_listener *listener, void *data)
 
     ivisurf = get_surface(&shell->list_surface, layout_surface);
     if (ivisurf == NULL) {
-        weston_log("id_surface is not created yet\n");
+        weston_log("surface_id is not created yet\n");
         return;
     }
 
@@ -1777,7 +1777,7 @@ check_layout_surfaces(struct ivishell *shell)
     struct ivi_layout_surface **pArray = NULL;
     struct ivisurface *ivisurf = NULL;
     const struct ivi_layout_interface *lyt = shell->interface;
-    uint32_t id_surface = 0;
+    uint32_t surface_id = 0;
     int32_t length = 0;
     uint32_t i = 0;
     int32_t ret = 0;
@@ -1794,8 +1794,8 @@ check_layout_surfaces(struct ivishell *shell)
     }
 
     for (i = 0; i < length; i++) {
-        id_surface = lyt->get_id_of_surface(pArray[i]);
-        ivisurf = create_surface(shell, pArray[i], id_surface);
+        surface_id = lyt->get_id_of_surface(pArray[i]);
+        ivisurf = create_surface(shell, pArray[i], surface_id);
         if (ivisurf == NULL) {
             weston_log("failed to create surface");
         }

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -223,7 +223,6 @@ send_surface_prop(struct wl_listener *listener, void *data)
     (void)data;
     enum ivi_layout_notification_mask mask;
     struct ivicontroller *ctrl;
-    const struct ivi_layout_interface *lyt = ivisurf->shell->interface;
     struct notification *not;
     uint32_t surface_id;
 
@@ -578,7 +577,6 @@ controller_surface_sync(struct wl_client *client,
                               int32_t sync_state)
 {
     struct ivicontroller *ctrl = wl_resource_get_user_data(resource);
-    const struct ivi_layout_interface *lyt = ctrl->shell->interface;
     struct ivi_layout_surface *layout_surface;
     struct ivisurface *ivisurf;
     const struct ivi_layout_surface_properties *prop;
@@ -631,7 +629,6 @@ controller_set_surface_type(struct wl_client *client, struct wl_resource *resour
                             uint32_t surface_id, int32_t type)
 {
     struct ivicontroller *ctrl = wl_resource_get_user_data(resource);
-    const struct ivi_layout_interface *lyt = ctrl->shell->interface;
     (void)client;
     struct ivi_layout_surface *layout_surface;
     struct ivisurface *ivisurf;
@@ -1609,7 +1606,6 @@ layer_event_create(struct wl_listener *listener, void *data)
 static void
 layer_event_remove(struct wl_listener *listener, void *data)
 {
-    struct wl_resource *resource;
     struct ivishell *shell = wl_container_of(listener, shell, layer_removed);
     struct ivilayer *ivilayer = NULL;
     struct ivicontroller *controller = NULL;
@@ -1647,7 +1643,6 @@ layer_event_remove(struct wl_listener *listener, void *data)
 static void
 surface_event_create(struct wl_listener *listener, void *data)
 {
-    struct wl_resource *resource;
     struct ivishell *shell = wl_container_of(listener, shell, surface_created);
     const struct ivi_layout_interface *lyt = shell->interface;
     struct ivisurface *ivisurf = NULL;
@@ -1669,7 +1664,6 @@ surface_event_create(struct wl_listener *listener, void *data)
 static void
 surface_event_remove(struct wl_listener *listener, void *data)
 {
-    struct wl_resource *resource;
     struct ivishell *shell = wl_container_of(listener, shell, surface_removed);
     struct ivicontroller *controller = NULL;
     struct ivisurface *ivisurf = NULL;
@@ -1708,7 +1702,6 @@ surface_event_remove(struct wl_listener *listener, void *data)
 static void
 surface_event_configure(struct wl_listener *listener, void *data)
 {
-    struct wl_resource *resource;
     struct ivishell *shell = wl_container_of(listener, shell, surface_configured);
     const struct ivi_layout_interface *lyt = shell->interface;
     struct ivisurface *ivisurf = NULL;

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -1700,25 +1700,21 @@ surface_event_remove(struct wl_listener *listener, void *data)
 }
 
 static void
-surface_event_configure(struct wl_listener *listener, void *data)
+configure_surface(struct ivishell *shell, struct ivi_layout_surface *layout_surface,
+        uint32_t surface_id)
 {
-    struct ivishell *shell = wl_container_of(listener, shell, surface_configured);
-    const struct ivi_layout_interface *lyt = shell->interface;
     struct ivisurface *ivisurf = NULL;
-    struct ivi_layout_surface *layout_surface =
-           (struct ivi_layout_surface *) data;
+    struct weston_surface *w_surface;
     struct ivicontroller *ctrl;
     struct notification *not;
-    uint32_t surface_id;
-    struct weston_surface *w_surface;
+
+    const struct ivi_layout_interface *lyt = shell->interface;
 
     ivisurf = get_surface(&shell->list_surface, layout_surface);
     if (ivisurf == NULL) {
         weston_log("surface_id is not created yet\n");
         return;
     }
-
-    surface_id = lyt->get_id_of_surface(layout_surface);
 
     if (ivisurf->type == IVI_WM_SURFACE_TYPE_DESKTOP) {
         w_surface = lyt->surface_get_weston_surface(layout_surface);
@@ -1740,6 +1736,21 @@ surface_event_configure(struct wl_listener *listener, void *data)
         send_surface_event(ctrl, ivisurf->layout_surface, surface_id, ivisurf->prop,
                            IVI_NOTIFICATION_CONFIGURE);
     }
+}
+
+static void
+surface_event_configure(struct wl_listener *listener, void *data)
+{
+    struct ivishell *shell = wl_container_of(listener, shell,
+            surface_configured);
+    const struct ivi_layout_interface *lyt = shell->interface;
+    struct ivi_layout_surface *layout_surface =
+            (struct ivi_layout_surface *) data;
+
+    uint32_t surface_id;
+    surface_id = lyt->get_id_of_surface(layout_surface);
+
+    configure_surface(shell, layout_surface, surface_id);
 }
 
 static int32_t

--- a/weston-ivi-shell/src/ivi-controller.h
+++ b/weston-ivi-shell/src/ivi-controller.h
@@ -27,6 +27,7 @@
 #include <weston/ivi-layout-export.h>
 
 struct ivisurface {
+    uint32_t surface_id;
     struct wl_list link;
     struct ivishell *shell;
     uint32_t update_count;

--- a/weston-ivi-shell/src/ivi-controller.h
+++ b/weston-ivi-shell/src/ivi-controller.h
@@ -25,6 +25,9 @@
 
 #include "ivi-wm-server-protocol.h"
 #include <weston/ivi-layout-export.h>
+#include <limits.h>
+
+#define IVI_INVALID_ID UINT_MAX
 
 struct ivisurface {
     uint32_t surface_id;


### PR DESCRIPTION
These changes prepare the distinction between ivi-apps and xdg-apps in the ivi-shell. Therefore an invalid id is introduced to obtain xdg-apps. Moreover ivi-controller and ivi-input-controller are now using the surface_id from the ivisurface instead of ivi-layout-surface. Also the existing callback functions are prepared for an id-agent to be used. These changes only add features to the existing ones and are not replacing them.