### PR TITLE
WLEyesRenderer: resolved warning for wl_pointer_set_cursor during compilation

### DIFF
--- a/ivi-layermanagement-examples/EGLWLInputEventExample/src/WLEyesRenderer.cpp
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/src/WLEyesRenderer.cpp
@@ -95,7 +95,7 @@ void WaitForEvent(struct wl_display* wlDisplay, int fd)
 //////////////////////////////////////////////////////////////////////////////
 
 static void
-set_pointer_image(struct seat_data* context)
+set_pointer_image(struct seat_data* context, uint32_t serial)
 {
     struct wl_cursor *cursor = NULL;
     struct wl_cursor_image *image = NULL;
@@ -120,7 +120,7 @@ set_pointer_image(struct seat_data* context)
         return;
     }
 
-    wl_pointer_set_cursor(context->wlPointer, NULL,
+    wl_pointer_set_cursor(context->wlPointer, serial,
                   context->ctx->GetPointerSurface(),
                   image->hotspot_x, image->hotspot_y);
 
@@ -144,7 +144,7 @@ PointerHandleEnter(void* data, struct wl_pointer* wlPointer, uint32_t serial,
     struct seat_data* context =
                    static_cast<struct seat_data*>(data);
 
-    set_pointer_image(context);
+    set_pointer_image(context, serial);
     printf("ENTER EGLWLINPUT PointerHandleEnter: x(%d), y(%d)\n",
            wl_fixed_to_int(sx), wl_fixed_to_int(sy));
 }


### PR DESCRIPTION
Bugfix: Formely a NULL pointer was given to wl_pointer_set_cursor although it was expecting the serial variable / an integer value. 