### PR TITLE
Unit test improvements v1

### DIFF
--- a/ivi-layermanagement-api/test/CMakeLists.txt
+++ b/ivi-layermanagement-api/test/CMakeLists.txt
@@ -56,6 +56,10 @@ IF(BUILD_ILM_API_TESTS)
         ilm_control_notification_test.cpp
     )
 
+    SET(GCC_SANITIZER_COMPILE_FLAGS "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover -fstack-protector")
+    SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_SANITIZER_COMPILE_FLAGS}" )
+    SET( CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -static-libasan" )
+
     ADD_EXECUTABLE(${PROJECT_NAME} ${SRC_FILES})
 
     TARGET_LINK_LIBRARIES(${PROJECT_NAME} ${LIBS})

--- a/ivi-layermanagement-api/test/CMakeLists.txt
+++ b/ivi-layermanagement-api/test/CMakeLists.txt
@@ -56,9 +56,9 @@ IF(BUILD_ILM_API_TESTS)
         ilm_control_notification_test.cpp
     )
 
-    SET(GCC_SANITIZER_COMPILE_FLAGS "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover -fstack-protector")
+    SET(GCC_SANITIZER_COMPILE_FLAGS "-fsanitize=address -fsanitize=undefined -fno-sanitize-recover -fstack-protector-all")
     SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_SANITIZER_COMPILE_FLAGS}" )
-    SET( CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -static-libasan" )
+    SET( CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -static-libasan -static-libubsan" )
 
     ADD_EXECUTABLE(${PROJECT_NAME} ${SRC_FILES})
 

--- a/ivi-layermanagement-api/test/TestBase.cpp
+++ b/ivi-layermanagement-api/test/TestBase.cpp
@@ -21,14 +21,82 @@
 #include "TestBase.h"
 #include <cstring>
 #include <stdexcept>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+
+int
+create_file(int size)
+{
+    static const char base_string[] = "/weston-shared-XXXXXX";
+    const char *path;
+    char *name;
+    int fd;
+    int ret;
+    long flags;
+
+    path = getenv("XDG_RUNTIME_DIR");
+    if (!path) {
+        errno = ENOENT;
+        return -1;
+    }
+
+    name = (char*) malloc(strlen(path) + sizeof(base_string));
+    if (!name)
+        return -1;
+
+    strcpy(name, path);
+    strcat(name, base_string);
+
+    fd = mkstemp(name);
+    if (fd >= 0) {
+        flags = fcntl(fd, F_GETFD);
+        fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+        unlink(name);
+    }
+
+    free(name);
+
+    if (fd < 0)
+        return -1;
+
+    ret = ftruncate(fd, size);
+    if (ret < 0) {
+        close(fd);
+        return -1;
+    }
+
+    return fd;
+}
+
+static void
+shm_format(void *data, struct wl_shm *wl_shm, uint32_t format)
+{
+    TestBase* base = static_cast<TestBase*>(data);
+
+    base->SetShmFormats(format);
+}
+
+static struct wl_shm_listener shm_listener = {
+    shm_format
+};
 
 void registry_listener_callback(void* data, struct wl_registry* registry, uint32_t id, const char* interface, uint32_t version)
 {
     TestBase* base = static_cast<TestBase*>(data);
+    struct wl_shm *shm;
 
     if (0 == strcmp(interface, "wl_compositor"))
     {
         base->SetWLCompositor(reinterpret_cast<wl_compositor*>(wl_registry_bind(registry, id, &wl_compositor_interface, 1)));
+    }
+
+    if (0 == strcmp(interface, "wl_shm"))
+    {
+        shm = (struct wl_shm*) wl_registry_bind(registry, id, &wl_shm_interface, 1);
+        wl_shm_add_listener(shm, &shm_listener, base);
+        base->SetShm(shm);
     }
 
     if (0 == strcmp(interface, "ivi_application"))
@@ -42,6 +110,11 @@ TestBase::TestBase()
 : wlDisplay(NULL)
 , wlRegistry(NULL)
 {
+    int fd = -1;
+    int size = 0;
+    struct wl_shm_pool *pool;
+    void* mmapData;
+
     wlDisplay = wl_display_connect(NULL);
     if (!wlDisplay)
     {
@@ -54,6 +127,8 @@ TestBase::TestBase()
         NULL
     };
 
+    shmFormats = 0;
+
     wl_registry_add_listener(wlRegistry, &registry_listener, this);
 
     if (wl_display_roundtrip(wlDisplay) == -1 || wl_display_roundtrip(wlDisplay) == -1)
@@ -61,15 +136,72 @@ TestBase::TestBase()
         throw std::runtime_error("wl_display error");
     }
 
+    if (!wlShm)
+    {
+        throw std::runtime_error("shared memory buffers are not supported");
+    }
+
+    if (wl_display_roundtrip(wlDisplay) == -1)
+    {
+        throw std::runtime_error("wl_display error");
+    }
+
+    if (!(shmFormats & (1 << WL_SHM_FORMAT_ARGB8888)))
+    {
+        throw std::runtime_error("shared memory buffers format ARGB888 is not supported");
+    }
+
     wlSurfaces.reserve(10);
     for (int i = 0; i < (int)wlSurfaces.capacity(); ++i)
     {
         wlSurfaces.push_back(wl_compositor_create_surface(wlCompositor));
     }
+
+    // size = height * width * bpp * number_of_surfaces = 1 * 1 * 4 * 10
+    size = 4 * wlSurfaces.capacity();
+    fd = create_file(size);
+    if (fd < 0)
+    {
+        throw std::runtime_error("cannot create shared memory file");
+    }
+
+    mmapData = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (MAP_FAILED == mmapData) {
+        close(fd);
+        throw std::runtime_error("mmap failed");
+    }
+
+    pool = wl_shm_create_pool(wlShm, fd, size);
+    if (!pool)
+    {
+        throw std::runtime_error("wl_shm_create_pool error");
+    }
+
+    wlBuffers.reserve(10);
+    for (int i = 0; i < (int)wlBuffers.capacity(); ++i)
+    {
+        wlBuffers.push_back(wl_shm_pool_create_buffer(pool, 0, 1, 1, 4, WL_SHM_FORMAT_ARGB8888));
+        wl_surface_attach(wlSurfaces[i], wlBuffers[i], 0, 0);
+        wl_surface_damage(wlSurfaces[i], 0, 0, 1, 1);
+        wl_surface_commit(wlSurfaces[i]);
+        wl_display_flush(wlDisplay);
+    }
+
+    munmap(mmapData, size);
+    wl_shm_pool_destroy(pool);
+    close(fd);
 }
 
 TestBase::~TestBase()
 {
+    for (std::vector<wl_buffer *>::reverse_iterator it = wlBuffers.rbegin();
+         it != wlBuffers.rend();
+         ++it)
+    {
+        wl_buffer_destroy(*it);
+    }
+    wlBuffers.clear();
+
     for (std::vector<wl_surface *>::reverse_iterator it = wlSurfaces.rbegin();
          it != wlSurfaces.rend();
          ++it)
@@ -77,6 +209,7 @@ TestBase::~TestBase()
         wl_surface_destroy(*it);
     }
     wlSurfaces.clear();
+    wl_shm_destroy(wlShm);
     wl_compositor_destroy(wlCompositor);
     ivi_application_destroy(iviApp);
     wl_registry_destroy(wlRegistry);

--- a/ivi-layermanagement-api/test/TestBase.h
+++ b/ivi-layermanagement-api/test/TestBase.h
@@ -34,12 +34,17 @@ public:
     virtual ~TestBase();
     void SetWLCompositor(struct wl_compositor* wlCompositor);
     void SetIviApp(struct ivi_application* iviApp);
+    void SetShm(struct wl_shm* wlShm);
+    void SetShmFormats(uint32_t format);
 
 protected:
     std::vector<wl_surface *> wlSurfaces;
     std::vector<iviSurface> iviSurfaces;
+    std::vector<wl_buffer *> wlBuffers;
     wl_display*    wlDisplay;
     ivi_application* iviApp;
+    wl_shm* wlShm;
+    uint32_t shmFormats;
 
 private:
     wl_registry*   wlRegistry;
@@ -50,3 +55,7 @@ inline void TestBase::SetWLCompositor(struct wl_compositor* wl_compositor)
     { wlCompositor = wl_compositor; }
 inline void TestBase::SetIviApp(struct ivi_application* ivi_application)
     { iviApp = ivi_application; }
+inline void TestBase::SetShm(struct wl_shm* wl_shm)
+    { wlShm = wl_shm; }
+inline void TestBase::SetShmFormats(uint32_t format)
+    { shmFormats |= format; }

--- a/ivi-layermanagement-api/test/TestBase.h
+++ b/ivi-layermanagement-api/test/TestBase.h
@@ -25,6 +25,11 @@
 class TestBase
 {
 public:
+    struct iviSurface
+    {
+        ivi_surface* surface;
+        int surface_id;
+    };
     TestBase();
     virtual ~TestBase();
     void SetWLCompositor(struct wl_compositor* wlCompositor);
@@ -32,6 +37,7 @@ public:
 
 protected:
     std::vector<wl_surface *> wlSurfaces;
+    std::vector<iviSurface> iviSurfaces;
     wl_display*    wlDisplay;
     ivi_application* iviApp;
 

--- a/ivi-layermanagement-api/test/ilm_control_test.cpp
+++ b/ivi-layermanagement-api/test/ilm_control_test.cpp
@@ -557,9 +557,7 @@ TEST_F(IlmCommandTest, ilm_takeScreenshot) {
     }
 
     ASSERT_EQ(ILM_SUCCESS, ilm_takeScreenshot(0, outputFile));
-    ASSERT_EQ(ILM_SUCCESS, ilm_getError());
 
-    sleep(1);
     f = fopen(outputFile, "r");
     ASSERT_TRUE(f!=NULL);
     fclose(f);
@@ -595,9 +593,7 @@ TEST_F(IlmCommandTest, ilm_takeSurfaceScreenshot) {
     uint surface = iviSurfaces[0].surface_id;
     ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
     ASSERT_EQ(ILM_SUCCESS, ilm_takeSurfaceScreenshot(outputFile, surface));
-    ASSERT_EQ(ILM_SUCCESS, ilm_getError());
 
-    sleep(1);
     f = fopen(outputFile, "r");
     ASSERT_TRUE(f!=NULL);
     fclose(f);

--- a/ivi-layermanagement-api/test/ilm_control_test.cpp
+++ b/ivi-layermanagement-api/test/ilm_control_test.cpp
@@ -45,6 +45,15 @@ public:
     void SetUp()
     {
         ASSERT_EQ(ILM_SUCCESS, ilm_initWithNativedisplay((t_ilm_nativedisplay)wlDisplay));
+
+        iviSurfaces.reserve(10);
+        struct iviSurface surf;
+        for (int i = 0; i < (int)iviSurfaces.capacity(); ++i)
+        {
+            surf.surface = ivi_application_surface_create(iviApp, i+500, wlSurfaces[i]);
+            surf.surface_id = i+500;
+            iviSurfaces.push_back(surf);
+        }
     }
 
     void TearDown()
@@ -58,6 +67,14 @@ public:
             EXPECT_EQ(ILM_SUCCESS, ilm_layerRemove(layers[i]));
         };
         free(layers);
+
+        for (std::vector<iviSurface>::reverse_iterator it = iviSurfaces.rbegin();
+             it != iviSurfaces.rend();
+             ++it)
+        {
+            ivi_surface_destroy((*it).surface);
+        }
+        iviSurfaces.clear();
 
         EXPECT_EQ(ILM_SUCCESS, ilm_commitChanges());
         EXPECT_EQ(ILM_SUCCESS, ilm_destroy());

--- a/ivi-layermanagement-api/test/ilm_control_test.cpp
+++ b/ivi-layermanagement-api/test/ilm_control_test.cpp
@@ -31,15 +31,6 @@ extern "C" {
     #include "ilm_control.h"
 }
 
-template <typename T>
-bool contains(T const *actual, size_t as, T expected)
-{
-   for (unsigned i = 0; i < as; i++)
-      if (actual[i] == expected)
-         return true;
-   return false;
-}
-
 class IlmCommandTest : public TestBase, public ::testing::Test {
 public:
     void SetUp()
@@ -54,6 +45,8 @@ public:
             surf.surface_id = i+500;
             iviSurfaces.push_back(surf);
         }
+
+        wl_display_flush(wlDisplay);
     }
 
     void TearDown()
@@ -82,14 +75,9 @@ public:
 };
 
 TEST_F(IlmCommandTest, SetGetSurfaceOpacity) {
-    uint surface1 = 36;
-    uint surface2 = 44;
+    uint surface1 = iviSurfaces[0].surface_id;
+    uint surface2 = iviSurfaces[1].surface_id;
     t_ilm_float opacity;
-
-    struct ivi_surface* ivi_surface1 = (struct ivi_surface*)
-        ivi_application_surface_create(iviApp, surface1, wlSurfaces[0]);
-    struct ivi_surface* ivi_surface2 = (struct ivi_surface*)
-        ivi_application_surface_create(iviApp, surface2, wlSurfaces[1]);
 
     ASSERT_EQ(ILM_SUCCESS, ilm_surfaceSetOpacity(surface1, 0.88));
     ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
@@ -100,9 +88,6 @@ TEST_F(IlmCommandTest, SetGetSurfaceOpacity) {
     ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
     ASSERT_EQ(ILM_SUCCESS, ilm_surfaceGetOpacity(surface2, &opacity));
     EXPECT_NEAR(0.001, opacity, 0.01);
-
-    ivi_surface_destroy(ivi_surface1);
-    ivi_surface_destroy(ivi_surface2);
 }
 
 TEST_F(IlmCommandTest, SetGetSurfaceOpacity_InvalidInput) {
@@ -143,11 +128,8 @@ TEST_F(IlmCommandTest, SetGetLayerOpacity_InvalidInput) {
 }
 
 TEST_F(IlmCommandTest, SetGetSurfaceVisibility) {
-    uint surface = 36;
+    uint surface = iviSurfaces[0].surface_id;
     t_ilm_bool visibility;
-
-    struct ivi_surface* ivi_surface = (struct ivi_surface*)
-        ivi_application_surface_create(iviApp, surface, wlSurfaces[0]);
 
     ASSERT_EQ(ILM_SUCCESS, ilm_surfaceSetVisibility(surface, ILM_TRUE));
     ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
@@ -163,8 +145,6 @@ TEST_F(IlmCommandTest, SetGetSurfaceVisibility) {
     ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
     ASSERT_EQ(ILM_SUCCESS, ilm_surfaceGetVisibility(surface, &visibility));
     ASSERT_EQ(ILM_TRUE, visibility);
-
-    ivi_surface_destroy(ivi_surface);
 }
 
 TEST_F(IlmCommandTest, SetGetSurfaceVisibility_InvalidInput) {
@@ -212,9 +192,7 @@ TEST_F(IlmCommandTest, SetGetLayerVisibility_InvalidInput) {
 }
 
 TEST_F(IlmCommandTest, SetSurfaceSourceRectangle) {
-    t_ilm_uint surface = 0xbeef;
-    struct ivi_surface* ivi_surface = (struct ivi_surface*)
-        ivi_application_surface_create(iviApp, surface, wlSurfaces[0]);
+    t_ilm_uint surface = iviSurfaces[0].surface_id;
 
     ASSERT_EQ(ILM_SUCCESS, ilm_surfaceSetSourceRectangle(surface, 89, 6538, 638, 4));
     ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
@@ -225,8 +203,6 @@ TEST_F(IlmCommandTest, SetSurfaceSourceRectangle) {
     ASSERT_EQ(6538u, surfaceProperties.sourceY);
     ASSERT_EQ(638u, surfaceProperties.sourceWidth);
     ASSERT_EQ(4u, surfaceProperties.sourceHeight);
-
-    ivi_surface_destroy(ivi_surface);
 }
 
 TEST_F(IlmCommandTest, SetSurfaceSourceRectangle_InvalidInput) {
@@ -319,69 +295,16 @@ TEST_F(IlmCommandTest, ilm_getLayerIDsOfScreen) {
 }
 
 TEST_F(IlmCommandTest, ilm_getSurfaceIDs) {
-    uint surface1 = 3246;
-    uint surface2 = 46586;
     t_ilm_uint* IDs;
-    t_ilm_int old_length;
-
-    ASSERT_EQ(ILM_SUCCESS, ilm_getSurfaceIDs(&old_length, &IDs));
-    struct ivi_surface* ivi_surface1 = (struct ivi_surface*)
-        ivi_application_surface_create(iviApp, surface1, wlSurfaces[0]);
-    struct ivi_surface* ivi_surface2 = (struct ivi_surface*)
-        ivi_application_surface_create(iviApp, surface2, wlSurfaces[1]);
-    ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
-    free(IDs);
-
     t_ilm_int length;
+
     ASSERT_EQ(ILM_SUCCESS, ilm_getSurfaceIDs(&length, &IDs));
 
-    EXPECT_EQ(old_length+2, length);
-    if (length == old_length+2)
+    EXPECT_EQ(iviSurfaces.size(), length);
+    for (int i=0; i < iviSurfaces.size(); i++)
     {
-        EXPECT_TRUE(contains(IDs+old_length, 2, surface1));
-        EXPECT_TRUE(contains(IDs+old_length, 2, surface2));
+        EXPECT_EQ(IDs[i], iviSurfaces[i].surface_id);
     }
-    free(IDs);
-
-    ivi_surface_destroy(ivi_surface1);
-    ivi_surface_destroy(ivi_surface2);
-}
-
-TEST_F(IlmCommandTest, ilm_surfaceCreate_Remove) {
-    uint surface1 = 3246;
-    uint surface2 = 46586;
-    struct ivi_surface* ivi_surface1 = (struct ivi_surface*)
-        ivi_application_surface_create(iviApp, surface1, wlSurfaces[0]);
-    struct ivi_surface* ivi_surface2 = (struct ivi_surface*)
-        ivi_application_surface_create(iviApp, surface2, wlSurfaces[1]);
-    ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
-
-    t_ilm_int length;
-    t_ilm_uint* IDs;
-    ASSERT_EQ(ILM_SUCCESS, ilm_getSurfaceIDs(&length, &IDs));
-
-    EXPECT_EQ(length, 2);
-    if (length == 2)
-    {
-        EXPECT_TRUE(contains(IDs, 2, surface1));
-        EXPECT_TRUE(contains(IDs, 2, surface2));
-    }
-    free(IDs);
-
-    ivi_surface_destroy(ivi_surface1);
-    ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
-    ASSERT_EQ(ILM_SUCCESS, ilm_getSurfaceIDs(&length, &IDs));
-    EXPECT_EQ(length, 1);
-    if (length == 1)
-    {
-        EXPECT_EQ(surface2, IDs[0]);
-    }
-    free(IDs);
-
-    ivi_surface_destroy(ivi_surface2);
-    ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
-    EXPECT_EQ(ILM_SUCCESS, ilm_getSurfaceIDs(&length, &IDs));
-    EXPECT_EQ(length, 0);
     free(IDs);
 }
 
@@ -458,13 +381,8 @@ TEST_F(IlmCommandTest, ilm_layerRemove_InvalidUse) {
 TEST_F(IlmCommandTest, ilm_layerAddSurface_ilm_layerRemoveSurface_ilm_getSurfaceIDsOnLayer) {
     uint layer = 3246;
     ASSERT_EQ(ILM_SUCCESS, ilm_layerCreateWithDimension(&layer, 800, 480));
-    uint surface1 = 3246;
-    uint surface2 = 46586;
-    struct ivi_surface* ivi_surface1 = (struct ivi_surface*)
-        ivi_application_surface_create(iviApp, surface1, wlSurfaces[0]);
-    struct ivi_surface* ivi_surface2 = (struct ivi_surface*)
-        ivi_application_surface_create(iviApp, surface2, wlSurfaces[1]);
-    ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
+    uint surface1 = iviSurfaces[0].surface_id;
+    uint surface2 = iviSurfaces[1].surface_id;
 
     t_ilm_int length;
     t_ilm_uint* IDs;
@@ -508,9 +426,6 @@ TEST_F(IlmCommandTest, ilm_layerAddSurface_ilm_layerRemoveSurface_ilm_getSurface
     ASSERT_EQ(ILM_SUCCESS, ilm_getSurfaceIDsOnLayer(layer, &length, &IDs));
     free(IDs);
     ASSERT_EQ(length, 0);
-
-    ivi_surface_destroy(ivi_surface1);
-    ivi_surface_destroy(ivi_surface2);
 }
 
 TEST_F(IlmCommandTest, ilm_getSurfaceIDsOnLayer_InvalidInput) {
@@ -524,16 +439,9 @@ TEST_F(IlmCommandTest, ilm_getSurfaceIDsOnLayer_InvalidInput) {
 TEST_F(IlmCommandTest, ilm_getSurfaceIDsOnLayer_InvalidResources) {
     uint layer = 3246;
     ASSERT_EQ(ILM_SUCCESS, ilm_layerCreateWithDimension(&layer, 800, 480));
-    uint surface1 = 0xbeef1;
-    uint surface2 = 0xbeef2;
-    uint surface3 = 0xbeef3;
-    struct ivi_surface* ivi_surface1 = (struct ivi_surface*)
-        ivi_application_surface_create(iviApp, surface1, wlSurfaces[0]);
-    struct ivi_surface* ivi_surface2 = (struct ivi_surface*)
-        ivi_application_surface_create(iviApp, surface2, wlSurfaces[1]);
-    struct ivi_surface* ivi_surface3 = (struct ivi_surface*)
-        ivi_application_surface_create(iviApp, surface3, wlSurfaces[2]);
-    ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
+    uint surface1 = iviSurfaces[0].surface_id;
+    uint surface2 = iviSurfaces[1].surface_id;
+    uint surface3 = iviSurfaces[2].surface_id;
 
     t_ilm_int length;
     t_ilm_uint IDs[3];
@@ -544,17 +452,10 @@ TEST_F(IlmCommandTest, ilm_getSurfaceIDsOnLayer_InvalidResources) {
     ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
 
     ASSERT_NE(ILM_SUCCESS, ilm_getSurfaceIDsOnLayer(layer, &length, NULL));
-
-    ivi_surface_destroy(ivi_surface1);
-    ivi_surface_destroy(ivi_surface2);
-    ivi_surface_destroy(ivi_surface3);
 }
 
 TEST_F(IlmCommandTest, ilm_getPropertiesOfSurface_ilm_surfaceSetSourceRectangle_ilm_surfaceSetDestinationRectangle) {
-    t_ilm_uint surface = 0xbeef;
-    struct ivi_surface* ivi_surface = (struct ivi_surface*)
-        ivi_application_surface_create(iviApp, surface, wlSurfaces[0]);
-    ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
+    uint surface = iviSurfaces[0].surface_id;
 
     ASSERT_EQ(ILM_SUCCESS, ilm_surfaceSetOpacity(surface, 0.8765));
     ASSERT_EQ(ILM_SUCCESS, ilm_surfaceSetSourceRectangle(surface, 89, 6538, 638, 4));
@@ -594,8 +495,6 @@ TEST_F(IlmCommandTest, ilm_getPropertiesOfSurface_ilm_surfaceSetSourceRectangle_
     ASSERT_EQ(3u, surfaceProperties2.destWidth);
     ASSERT_EQ(4316u, surfaceProperties2.destHeight);
     ASSERT_FALSE(surfaceProperties2.visibility);
-
-    ivi_surface_destroy(ivi_surface);
 }
 
 TEST_F(IlmCommandTest, ilm_getPropertiesOfLayer_ilm_layerSetSourceRectangle_ilm_layerSetDestinationRectangle) {
@@ -693,9 +592,7 @@ TEST_F(IlmCommandTest, ilm_takeSurfaceScreenshot) {
         ASSERT_EQ(0, result);
     }
 
-    t_ilm_surface surface = 0xbeef;
-    struct ivi_surface* ivi_surface = (struct ivi_surface*)
-        ivi_application_surface_create(iviApp, surface, wlSurfaces[0]);
+    uint surface = iviSurfaces[0].surface_id;
     ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
     ASSERT_EQ(ILM_SUCCESS, ilm_takeSurfaceScreenshot(outputFile, surface));
     ASSERT_EQ(ILM_SUCCESS, ilm_getError());
@@ -705,7 +602,6 @@ TEST_F(IlmCommandTest, ilm_takeSurfaceScreenshot) {
     ASSERT_TRUE(f!=NULL);
     fclose(f);
     remove(outputFile);
-    ivi_surface_destroy(ivi_surface);
 }
 
 TEST_F(IlmCommandTest, ilm_takeSurfaceScreenshot_InvalidInputs) {
@@ -849,13 +745,12 @@ TEST_F(IlmCommandTest, DisplaySetRenderOrder_shrinking) {
 
 TEST_F(IlmCommandTest, LayerSetRenderOrder_growing) {
     //prepare needed layers and surfaces
-    unsigned int renderOrder[] = {10, 20, 30};
-    t_ilm_uint surfaceCount = sizeof(renderOrder) / sizeof(renderOrder[0]);
-    struct ivi_surface* ivi_surfaces[surfaceCount];
+    unsigned int renderOrder[] = {0, 0, 0};
+    t_ilm_uint surfaceCount = 3;
 
     for (unsigned int i = 0; i < surfaceCount; ++i)
     {
-        ivi_surfaces[i] = (struct ivi_surface*) ivi_application_surface_create(iviApp, renderOrder[i], wlSurfaces[i]);
+        renderOrder[i] = iviSurfaces[i].surface_id;
     }
 
     t_ilm_layer layerIDs[] = {0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
@@ -866,10 +761,6 @@ TEST_F(IlmCommandTest, LayerSetRenderOrder_growing) {
         ASSERT_EQ(ILM_SUCCESS, ilm_layerCreateWithDimension(layerIDs + i, 300, 300));
         ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
     }
-
-    t_ilm_display* screenIDs;
-    t_ilm_uint screenCount;
-    ASSERT_EQ(ILM_SUCCESS, ilm_getScreenIDs(&screenCount, &screenIDs));
 
     for(unsigned int i = 0; i < layerCount; ++i)
     {
@@ -899,24 +790,16 @@ TEST_F(IlmCommandTest, LayerSetRenderOrder_growing) {
         EXPECT_EQ(ILM_SUCCESS, ilm_layerSetRenderOrder(layer, renderOrder, 0));
         EXPECT_EQ(ILM_SUCCESS, ilm_commitChanges());
     }
-
-    for (unsigned int i = 0; i < surfaceCount; ++i)
-    {
-        ivi_surface_destroy(ivi_surfaces[i]);
-    }
-
-    free(screenIDs);
 }
 
 TEST_F(IlmCommandTest, LayerSetRenderOrder_shrinking) {
     //prepare needed layers and surfaces
-    unsigned int renderOrder[] = {10, 20, 30};
-    t_ilm_uint surfaceCount = sizeof(renderOrder) / sizeof(renderOrder[0]);
-    struct ivi_surface* ivi_surfaces[surfaceCount];
+    unsigned int renderOrder[] = {0, 0, 0};
+    t_ilm_uint surfaceCount = 3;
 
     for (unsigned int i = 0; i < surfaceCount; ++i)
     {
-        ivi_surfaces[i] = (struct ivi_surface*) ivi_application_surface_create(iviApp, renderOrder[i], wlSurfaces[i]);
+        renderOrder[i] = iviSurfaces[i].surface_id;
     }
 
     t_ilm_layer layerIDs[] = {0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
@@ -927,10 +810,6 @@ TEST_F(IlmCommandTest, LayerSetRenderOrder_shrinking) {
         ASSERT_EQ(ILM_SUCCESS, ilm_layerCreateWithDimension(layerIDs + i, 300, 300));
         ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
     }
-
-    t_ilm_display* screenIDs;
-    t_ilm_uint screenCount;
-    ASSERT_EQ(ILM_SUCCESS, ilm_getScreenIDs(&screenCount, &screenIDs));
 
     for(unsigned int i = 0; i < layerCount; ++i)
     {
@@ -960,24 +839,16 @@ TEST_F(IlmCommandTest, LayerSetRenderOrder_shrinking) {
         EXPECT_EQ(ILM_SUCCESS, ilm_layerSetRenderOrder(layer, renderOrder, 0));
         EXPECT_EQ(ILM_SUCCESS, ilm_commitChanges());
     }
-
-    for (unsigned int i = 0; i < surfaceCount; ++i)
-    {
-        ivi_surface_destroy(ivi_surfaces[i]);
-    }
-
-    free(screenIDs);
 }
 
 TEST_F(IlmCommandTest, LayerSetRenderOrder_duplicates) {
     //prepare needed layers and surfaces
-    unsigned int renderOrder[] = {10, 20, 30};
-    t_ilm_uint surfaceCount = sizeof(renderOrder) / sizeof(renderOrder[0]);
-    struct ivi_surface* ivi_surfaces[surfaceCount];
+    unsigned int renderOrder[] = {0, 0, 0};
+    t_ilm_uint surfaceCount = 3;
 
     for (unsigned int i = 0; i < surfaceCount; ++i)
     {
-        ivi_surfaces[i] = (struct ivi_surface*) ivi_application_surface_create(iviApp, renderOrder[i], wlSurfaces[i]);
+        renderOrder[i] = iviSurfaces[i].surface_id;
     }
 
     t_ilm_surface duplicateRenderOrder[] = {renderOrder[0], renderOrder[1], renderOrder[0], renderOrder[1], renderOrder[0]};
@@ -986,11 +857,6 @@ TEST_F(IlmCommandTest, LayerSetRenderOrder_duplicates) {
     t_ilm_layer layer = 0xFFFFFFFF;
     ASSERT_EQ(ILM_SUCCESS, ilm_layerCreateWithDimension(&layer, 300, 300));
     ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
-
-    t_ilm_display* screenIDs;
-    t_ilm_uint screenCount;
-    ASSERT_EQ(ILM_SUCCESS, ilm_getScreenIDs(&screenCount, &screenIDs));
-    free(screenIDs);
 
     t_ilm_int layerSurfaceCount;
     t_ilm_surface* layerSurfaceIDs;
@@ -1002,32 +868,21 @@ TEST_F(IlmCommandTest, LayerSetRenderOrder_duplicates) {
     free(layerSurfaceIDs);
 
     ASSERT_EQ(2, layerSurfaceCount);
-
-    for (unsigned int i = 0; i < surfaceCount; ++i)
-    {
-        ivi_surface_destroy(ivi_surfaces[i]);
-    }
 }
 
 TEST_F(IlmCommandTest, LayerSetRenderOrder_empty) {
     //prepare needed layers and surfaces
-    unsigned int renderOrder[] = {10, 20, 30};
-    t_ilm_uint surfaceCount = sizeof(renderOrder) / sizeof(renderOrder[0]);
-    struct ivi_surface* ivi_surfaces[surfaceCount];
+    unsigned int renderOrder[] = {0, 0, 0};
+    t_ilm_uint surfaceCount = 3;
 
     for (unsigned int i = 0; i < surfaceCount; ++i)
     {
-        ivi_surfaces[i] = (struct ivi_surface*) ivi_application_surface_create(iviApp, renderOrder[i], wlSurfaces[i]);
+        renderOrder[i] = iviSurfaces[i].surface_id;
     }
 
     t_ilm_layer layer = 0xFFFFFFFF;
     ASSERT_EQ(ILM_SUCCESS, ilm_layerCreateWithDimension(&layer, 300, 300));
     ASSERT_EQ(ILM_SUCCESS, ilm_commitChanges());
-
-    t_ilm_display* screenIDs;
-    t_ilm_uint screenCount;
-    ASSERT_EQ(ILM_SUCCESS, ilm_getScreenIDs(&screenCount, &screenIDs));
-    free(screenIDs);
 
     t_ilm_int layerSurfaceCount;
     t_ilm_surface* layerSurfaceIDs;
@@ -1043,9 +898,4 @@ TEST_F(IlmCommandTest, LayerSetRenderOrder_empty) {
     free(layerSurfaceIDs);
 
     ASSERT_EQ(0, layerSurfaceCount);
-
-    for (unsigned int i = 0; i < surfaceCount; ++i)
-    {
-        ivi_surface_destroy(ivi_surfaces[i]);
-    }
 }

--- a/ivi-layermanagement-api/test/ilm_control_test.cpp
+++ b/ivi-layermanagement-api/test/ilm_control_test.cpp
@@ -614,8 +614,7 @@ TEST_F(IlmCommandTest, ilm_takeSurfaceScreenshot_InvalidInputs) {
     }
 
     // try to dump an non-existing screen
-    ASSERT_EQ(ILM_SUCCESS, ilm_takeSurfaceScreenshot(outputFile, 0xdeadbeef));
-    ASSERT_EQ(ILM_ERROR_RESOURCE_NOT_FOUND, ilm_getError());
+    ASSERT_EQ(ILM_FAILED, ilm_takeSurfaceScreenshot(outputFile, 0xdeadbeef));
 
     // make sure, no screen dump file was created for invalid screen
     ASSERT_NE(0, remove(outputFile));


### PR DESCRIPTION
This PR:
- activates address sanitizer for unit tests
- Moves ivi-surface creation from testcases to SetUp() to avoid memory leaks in failing test-cases.
- Creates shared memory buffers and attaches to the surfaces
- Modifies SurfaceScreenshot test to except ILM_FAILED when it is called for not existing surface.
- Removes unnecessary sleep() in screenshot APIs.

Now every testcase is passing