### PR TITLE
Update share surface when client restarts

### DIFF
--- a/weston-ivi-shell/src/ivi-share.c
+++ b/weston-ivi-shell/src/ivi-share.c
@@ -38,6 +38,7 @@ struct ivi_share_nativesurface_client_link
     bool firstSendConfigureComp;
     struct wl_list link;                         /* ivi_share_nativesurface link */
     struct ivi_share_nativesurface *parent;
+    bool empty;
 };
 
 struct shell_surface
@@ -83,6 +84,13 @@ share_surface_destroy(struct wl_client *client,
     if (NULL == client_link) {
         weston_log("share_surface does not have user data\n");
         return;
+    }
+
+    if (client_link->empty) {
+        if (client_link->parent) {
+            free(client_link->parent);
+            client_link->parent = NULL;
+        }
     }
 
     wl_resource_destroy(resource);
@@ -384,6 +392,7 @@ add_nativesurface_client(struct ivi_share_nativesurface *nativesurface,
     link->client = client;
     link->firstSendConfigureComp = false;
     link->parent = nativesurface;
+    link->empty = (nativesurface->surface == NULL) ? true : false;
 
     wl_resource_set_implementation(link->resource, &share_surface_implementation,
                                    link, destroy_client_link);


### PR DESCRIPTION
Currently, simple-ivi-share cannot update share surface in case that the client such as simple-egl is killed and restarted. Therefore, this case should be considered because it is possible some applications actually could be killed and restarted by user or system problem.

In current implementation, simple-ivi-share does not call get_share_surface() any more when the client is killed, so memory leak does not occur. But, during implementation of  this feature, I found that the memory leak could be happened when getting a share surface if the original surface does not exist.

When the original surface does not exist, ivi-share creates an empty nativesurface and sets the state of share surface as not exist. This empty nativesurface is still exist in memory, so memory leak could be occured. Therefore, ivi_share_surface_destroy() should be called explicitly.