### PR TITLE
ivi-share: introduce release_shared_name request

### DIFF
--- a/ivi-layermanagement-examples/simple-ivi-share/src/simple-ivi-share.c
+++ b/ivi-layermanagement-examples/simple-ivi-share/src/simple-ivi-share.c
@@ -185,6 +185,7 @@ handle_share_surface_damage(void *data, struct ivi_share_surface *share_surface,
         if (window->share_buffer.eglimage != NULL) {
             pfEglDestroyImageKHR(display->egl.egldisplay,
                                  window->share_buffer.eglimage);
+            ivi_share_surface_release_shared_name(window->share_surface, window->share_buffer.name);
         }
 
         window->share_buffer.eglimage =
@@ -580,7 +581,7 @@ registry_handle_global(void *data, struct wl_registry *registry,
             wl_registry_bind(registry, name, &ivi_application_interface, 1);
     } else if (strcmp(interface, "ivi_share") == 0) {
         display->ivi_share =
-            wl_registry_bind(registry, name, &ivi_share_interface, 1);
+            wl_registry_bind(registry, name, &ivi_share_interface, 2);
     } else if (strcmp(interface, "wl_seat") == 0) {
         display->seat =
             wl_registry_bind(registry, name, &wl_seat_interface, 1);

--- a/protocol/ivi-share.xml
+++ b/protocol/ivi-share.xml
@@ -23,7 +23,7 @@
         THE SOFTWARE.
     </copyright>
 
-    <interface name="ivi_share" version="1">
+    <interface name="ivi_share" version="2">
         <description summary="get handle to manipulate ivi_surface">
           get handle ID to manipulate shared ivi_surface. The host ivi application
           can get trigger of update of the ivi_surface from client to draw it in host's
@@ -37,7 +37,7 @@
         </request>
     </interface>
 
-    <interface name="ivi_share_surface" version="1">
+    <interface name="ivi_share_surface" version="2">
         <description summary="extension interface for sharing a ivi_surface">
         </description>
 
@@ -135,5 +135,15 @@
             <description summary="state of shared surface"/>
             <arg name="state" type="uint"/>
         </event>
+
+        <!-- Version 2 additions -->
+
+        <request name="release_shared_name" since="2">
+            <description summary="consumer releases shared name">
+              Send when the consumer no longer uses the share name notified by the damage event.
+              Until the consumer notifies the release, the compositor will not release the buffer to the producer.
+            </description>
+            <arg name="name" type="uint"/>
+        </request>
     </interface>
 </protocol>

--- a/weston-ivi-shell/src/ivi-share-gbm.c
+++ b/weston-ivi-shell/src/ivi-share-gbm.c
@@ -33,8 +33,6 @@
 #include "ivi-share-server-protocol.h"
 #include "ivi-share.h"
 
-static uint32_t nativesurface_name;
-
 /* copied from libinput-seat.h of weston-1.9.0 */
 struct udev_input {
 	struct libinput *libinput;
@@ -92,16 +90,13 @@ struct drm_backend {
 };
 
 uint32_t
-get_buffer_name(struct weston_surface *surface,
-                struct ivi_shell_share_ext *shell_ext)
+get_buffer_name(struct ivi_share_nativesurface *nativesurface)
 {
-     (void)surface;
-     return nativesurface_name;
+     return nativesurface->name;
 }
 
 uint32_t
-update_buffer_nativesurface(struct ivi_share_nativesurface *p_nativesurface,
-                            struct ivi_shell_share_ext *shell_ext)
+update_buffer_nativesurface(struct ivi_share_nativesurface *p_nativesurface)
 {
     if (NULL == p_nativesurface || NULL == p_nativesurface->surface) {
         return IVI_SHAREBUFFER_NOT_AVAILABLE;
@@ -139,8 +134,6 @@ update_buffer_nativesurface(struct ivi_share_nativesurface *p_nativesurface,
     uint32_t stride = gbm_bo_get_stride(bo);
     uint32_t format = IVI_SHARE_SURFACE_FORMAT_ARGB8888;
     uint32_t ret    = IVI_SHAREBUFFER_STABLE;
-
-    nativesurface_name = name;
 
     if (name != p_nativesurface->name) {
         ret |= IVI_SHAREBUFFER_DAMAGE;

--- a/weston-ivi-shell/src/ivi-share-gbm.c
+++ b/weston-ivi-shell/src/ivi-share-gbm.c
@@ -116,14 +116,14 @@ update_buffer_nativesurface(struct ivi_share_nativesurface *p_nativesurface)
     struct gbm_bo *bo = gbm_bo_import(backend->gbm, GBM_BO_IMPORT_WL_BUFFER,
                                       buffer->legacy_buffer, GBM_BO_USE_SCANOUT);
     if (!bo) {
-        weston_log("failed to import gbm_bo\n");
+        weston_log("Texture Sharing Failed to import gbm_bo\n");
         return IVI_SHAREBUFFER_INVALID;
     }
 
     struct drm_gem_flink flink = {0};
     flink.handle = gbm_bo_get_handle(bo).u32;
     if (drmIoctl(gbm_device_get_fd(backend->gbm), DRM_IOCTL_GEM_FLINK, &flink) != 0) {
-        weston_log("gem_flink: returned non-zero failed\n");
+        weston_log("Texture Sharing gem_flink: returned non-zero failed\n");
         gbm_bo_destroy(bo);
         return IVI_SHAREBUFFER_INVALID;
     }

--- a/weston-ivi-shell/src/ivi-share.c
+++ b/weston-ivi-shell/src/ivi-share.c
@@ -593,8 +593,7 @@ bind_share_interface(struct wl_client *p_client, void *p_data,
 }
 
 static void
-send_to_client(struct ivi_share_nativesurface *p_nativesurface, uint32_t send_flag,
-               struct ivi_shell_share_ext *shell_ext)
+send_to_client(struct ivi_share_nativesurface *p_nativesurface, uint32_t send_flag)
 {
     struct ivi_share_nativesurface_client_link *p_link = NULL;
 
@@ -621,7 +620,7 @@ send_to_client(struct ivi_share_nativesurface *p_nativesurface, uint32_t send_fl
         }
         if ((IVI_SHAREBUFFER_DAMAGE & send_flag) == IVI_SHAREBUFFER_DAMAGE) {
             send_damage(p_link->resource, p_nativesurface->id,
-                        get_buffer_name(p_nativesurface->surface, shell_ext));
+                        get_buffer_name(p_nativesurface));
         }
     }
 }
@@ -652,8 +651,8 @@ send_nativesurface_event(struct wl_listener *listener, void *data)
             continue;
         }
 
-        p_nativesurface->send_flag = update_buffer_nativesurface(p_nativesurface, shell_ext);
-        send_to_client(p_nativesurface, p_nativesurface->send_flag, shell_ext);
+        p_nativesurface->send_flag = update_buffer_nativesurface(p_nativesurface);
+        send_to_client(p_nativesurface, p_nativesurface->send_flag);
     }
 }
 

--- a/weston-ivi-shell/src/ivi-share.c
+++ b/weston-ivi-shell/src/ivi-share.c
@@ -504,7 +504,7 @@ share_get_ivi_share_surface(struct wl_client *client, struct wl_resource *resour
 
     nativesurf = find_nativesurface(shsurf, shell_ext);
     if (nativesurf == NULL) {
-        nativesurf = alloc_share_nativesurface(shsurf->surface, id, 0,
+        nativesurf = alloc_share_nativesurface(shsurf->surface, id, shsurf->surface_id,
                                                (int32_t)IVI_SHARE_SURFACE_TYPE_GBM,
                                                (int32_t)IVI_SHARE_SURFACE_FORMAT_ARGB8888,
                                                shell_ext);

--- a/weston-ivi-shell/src/ivi-share.h
+++ b/weston-ivi-shell/src/ivi-share.h
@@ -28,6 +28,13 @@
  */
 #define IVI_BIT(x) (1 << (x))
 
+struct ivi_share_buffer_reference
+{
+	struct weston_buffer_reference ref;
+	uint32_t name;
+	uint32_t client_count;
+};
+
 struct ivi_share_nativesurface
 {
     struct weston_surface *surface; /* resource                                   */
@@ -44,6 +51,7 @@ struct ivi_share_nativesurface
     uint32_t send_flag;
     struct wl_listener surface_destroy_listener;
     struct ivi_shell_share_ext *shell_ext;
+    struct ivi_share_buffer_reference buffer_refs[2], *current, *back;
 };
 
 struct ivi_shell_share_ext

--- a/weston-ivi-shell/src/ivi-share.h
+++ b/weston-ivi-shell/src/ivi-share.h
@@ -69,7 +69,5 @@ enum ivi_sharebuffer_updatetype
 int32_t setup_buffer_sharing(struct weston_compositor *wc,
                              const struct ivi_layout_interface *interface);
 
-uint32_t get_buffer_name(struct weston_surface *surface,
-                         struct ivi_shell_share_ext *shell_ext);
-uint32_t update_buffer_nativesurface(struct ivi_share_nativesurface *nativesurface,
-                                     struct ivi_shell_share_ext *shell_ext);
+uint32_t get_buffer_name(struct ivi_share_nativesurface *native_surface);
+uint32_t update_buffer_nativesurface(struct ivi_share_nativesurface *nativesurface);


### PR DESCRIPTION
The compositor was unable to know whether shared buffers no longer needed.
Therefore, in spite of the consumer still using the buffer, the compositor was releasing the buffer to the producer.
In order to solve this problem, the request is introduced.