### PR TITLE
EGLWLMockNavigation: fix memory leak

### DIFF
--- a/ivi-layermanagement-examples/EGLWLMockNavigation/src/OpenGLES2App.cpp
+++ b/ivi-layermanagement-examples/EGLWLMockNavigation/src/OpenGLES2App.cpp
@@ -369,25 +369,7 @@ unsigned int OpenGLES2App::GetTickCount()
     return (unsigned int) (ts.tv_sec * 1000 + (ts.tv_usec / 1000));
 }
 
-extern "C" void
-OpenGLES2App::frame_listener_func(void *data, struct wl_callback *callback, uint32_t time)
-{
-    data = data; // TODO:to avoid warning
-    time = time; // TODO:to avoid warning
-    if (callback)
-    {
-        wl_callback_destroy(callback);
-    }
-}
-
-static const struct wl_callback_listener frame_listener = {
-    OpenGLES2App::frame_listener_func
-};
-
 void OpenGLES2App::swapBuffers()
 {
-    struct wl_callback* callback = wl_surface_frame(m_wlContextStruct.wlSurface);
-    wl_callback_add_listener(callback, &frame_listener, NULL);
-
     eglSwapBuffers(m_eglContextStruct.eglDisplay, m_eglContextStruct.eglSurface);
 }


### PR DESCRIPTION
MockNavi calls wl_surface_frame. However, it does not dispatch any default queue events.
Therefore, frame_listerner_func is never called and callback memory is leaked.
Originally, wl_surface_frame call is not needed and delete it.

Signed-off-by: Kenji Hosokawa <khosokawa@de.adit-jv.com>