### PR TITLE
layer-add-surfaces: follow the surface changing during running this a…

### DIFF
--- a/ivi-layermanagement-examples/layer-add-surfaces/src/layer-add-surfaces.c
+++ b/ivi-layermanagement-examples/layer-add-surfaces/src/layer-add-surfaces.c
@@ -79,11 +79,11 @@ static void callbackFunction(ilmObjectType object, t_ilm_uint id, t_ilm_bool cre
                 if ((sp.origSourceWidth != 0) && (sp.origSourceHeight !=0))
                 {   // surface is already configured
                     configure_ilm_surface(id, sp.origSourceWidth, sp.origSourceHeight);
-                } else {
-                    // wait for configured event
-                    ilm_surfaceAddNotification(id,&surfaceCallbackFunction);
-                    ilm_commitChanges();
                 }
+
+                // always get configured event to follow the surface changings
+                ilm_surfaceAddNotification(id,&surfaceCallbackFunction);
+                ilm_commitChanges();
             }
         }
         else if(!created)


### PR DESCRIPTION
…pplication

In most cases, after adding a surface to a layer, even if the size of the surface changes, it does not follow.
While this application is running, always get the configured event to follow the surface changings.

Signed-off-by: Kenji Hosokawa <khosokawa@de.adit-jv.com>