### PR TITLE
EGLWLMockNavigation: introduce sync option

### DIFF
--- a/ivi-layermanagement-examples/EGLWLMockNavigation/include/OpenGLES2App.h
+++ b/ivi-layermanagement-examples/EGLWLMockNavigation/include/OpenGLES2App.h
@@ -32,6 +32,7 @@ struct SurfaceConfiguration
     unsigned int surfaceId;
     unsigned int surfaceWidth;
     unsigned int surfaceHeight;
+    unsigned int sync;
     bool nosky;
 };
 
@@ -55,7 +56,7 @@ private:
     bool createWLContext(SurfaceConfiguration* config);
     void destroyWLContext();
 
-    bool createEGLContext();
+    bool createEGLContext(SurfaceConfiguration* config);
     void destroyEglContext();
 
     unsigned int GetTickCount();

--- a/ivi-layermanagement-examples/EGLWLMockNavigation/src/OpenGLES2App.cpp
+++ b/ivi-layermanagement-examples/EGLWLMockNavigation/src/OpenGLES2App.cpp
@@ -129,7 +129,7 @@ OpenGLES2App::OpenGLES2App(float fps, float animationSpeed, SurfaceConfiguration
 , m_surfaceId(0)
 {
     createWLContext(config);
-    createEGLContext();
+    createEGLContext(config);
 
     if (config->nosky)
     {
@@ -240,7 +240,7 @@ bool OpenGLES2App::createWLContext(SurfaceConfiguration* config)
     return result;
 }
 
-bool OpenGLES2App::createEGLContext()
+bool OpenGLES2App::createEGLContext(SurfaceConfiguration* config)
 {
     bool result = true;
     EGLint eglstatus = EGL_SUCCESS;
@@ -311,7 +311,7 @@ bool OpenGLES2App::createEGLContext()
     eglMakeCurrent(m_eglContextStruct.eglDisplay,
             m_eglContextStruct.eglSurface, m_eglContextStruct.eglSurface,
             m_eglContextStruct.eglContext);
-    eglSwapInterval(m_eglContextStruct.eglDisplay, 1);
+    eglSwapInterval(m_eglContextStruct.eglDisplay, config->sync);
     eglstatus = eglGetError();
     if (eglstatus != EGL_SUCCESS)
     {

--- a/ivi-layermanagement-examples/EGLWLMockNavigation/src/main.cpp
+++ b/ivi-layermanagement-examples/EGLWLMockNavigation/src/main.cpp
@@ -32,6 +32,7 @@ using std::cout;
 #define DEFAULT_OPACITY  1.0
 #define DEFAULT_NOSKY    false
 #define DEFAULT_HELP     false
+#define DEFAULT_SYNC     1
 
 int main (int argc, const char * argv[])
 {
@@ -42,6 +43,7 @@ int main (int argc, const char * argv[])
     IntArgument height("height", DEFAULT_HEIGHT, argc, argv);
     BoolArgument nosky("nosky", DEFAULT_NOSKY, argc, argv);
     BoolArgument help("help", DEFAULT_HELP, argc, argv);
+    UnsignedIntArgument sync("sync", DEFAULT_SYNC, argc, argv);
 
     if (help.get())
     {
@@ -53,7 +55,8 @@ int main (int argc, const char * argv[])
              << "  -nosky        do not render sky, background transparent (default " << DEFAULT_NOSKY << ")\n"
              << "  -surface x    render to surface id x (default " << DEFAULT_SURFACE << ")\n"
              << "  -width x      set surface width to x (default " << DEFAULT_WIDTH << ")\n"
-             << "  -height x     set surface height to x (default " << DEFAULT_HEIGHT << ")\n\n";
+             << "  -height x     set surface height to x (default " << DEFAULT_HEIGHT << ")\n"
+             << "  -sync x       sync with frame callback or not (default " << DEFAULT_SYNC << ")\n\n";
     }
     else
     {
@@ -62,6 +65,7 @@ int main (int argc, const char * argv[])
         config.surfaceWidth = width.get();
         config.surfaceHeight = height.get();
         config.nosky = nosky.get();
+        config.sync = sync.get();
 
         MockNavi navi(fps.get(), animSpeed.get(), &config);
         navi.mainloop();


### PR DESCRIPTION
This option used for eglSwapInterval API. Default value is 1. This means rendering is synced with frame callback.
When it is set to 0, EGLWLMockNavigation will not sync with frame callback and render it independently.

Signed-off-by: Kenji Hosokawa <khosokawa@de.adit-jv.com>