### PR TITLE
Remove ivi extension static library

### DIFF
--- a/ivi-input-api/ilmInput/CMakeLists.txt
+++ b/ivi-input-api/ilmInput/CMakeLists.txt
@@ -28,8 +28,27 @@ pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
 
 GET_TARGET_PROPERTY(ILM_CONTROL_INCLUDE_DIRS ilmControl INCLUDE_DIRECTORIES)
 
+find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
+
+add_custom_command(
+    OUTPUT  ivi-input-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-input-client-protocol.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
+)
+
+add_custom_command(
+    OUTPUT  ivi-input-protocol.c
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-input-protocol.c
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
+)
+
 include_directories(
     include
+    ${CMAKE_CURRENT_BINARY_DIR}
     ${ILM_CONTROL_INCLUDE_DIRS}
     ${WAYLAND_CLIENT_INCLUDE_DIR}
 )
@@ -40,6 +59,8 @@ link_directories(
 
 add_library(${PROJECT_NAME} SHARED
     src/ilm_input.c
+    ivi-input-client-protocol.h
+    ivi-input-protocol.c
 )
 
 add_dependencies(${PROJECT_NAME}
@@ -50,7 +71,6 @@ add_dependencies(${PROJECT_NAME}
 set(LIBS
     ${LIBS}
     ilmControl
-    ivi-extension-protocol
     rt
     dl
     ${CMAKE_THREAD_LIBS_INIT}

--- a/ivi-input-modules/ivi-input-controller/CMakeLists.txt
+++ b/ivi-input-modules/ivi-input-controller/CMakeLists.txt
@@ -26,13 +26,30 @@ pkg_check_modules(WAYLAND_SERVER wayland-server REQUIRED)
 pkg_check_modules(WESTON weston REQUIRED)
 pkg_check_modules(PIXMAN pixman-1 REQUIRED)
 
-GET_TARGET_PROPERTY(IVI_EXTENSION_INCLUDE_DIRS ivi-extension-protocol INCLUDE_DIRECTORIES)
 GET_TARGET_PROPERTY(ILM_COMMON_INCLUDE_DIRS ilmCommon INCLUDE_DIRECTORIES)
 GET_TARGET_PROPERTY(IVI_CONTROLLER_INCLUDE_DIRS ivi-controller INCLUDE_DIRECTORIES)
 
+find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
+
+add_custom_command(
+    OUTPUT  ivi-input-server-protocol.h
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} server-header
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-input-server-protocol.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
+)
+
+add_custom_command(
+    OUTPUT  ivi-input-protocol.c
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-input-protocol.c
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
+)
+
 include_directories(
     include
-    ${IVI_EXTENSION_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_BINARY_DIR}
     ${ILM_COMMON_INCLUDE_DIRS}
     ${IVI_CONTROLLER_INCLUDE_DIRS}
     ${WAYLAND_SERVER_INCLUDE_DIRS}
@@ -49,12 +66,13 @@ link_directories(
 
 add_library(${PROJECT_NAME} MODULE
     src/ivi-input-controller.c
+    ivi-input-server-protocol.h
+    ivi-input-protocol.c
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
 
 add_dependencies(${PROJECT_NAME}
-    ivi-extension-protocol
     ilmCommon
     ${WAYLAND_SERVER_LIBRARIES}
     ${WESTON_LIBRARIES}
@@ -63,7 +81,6 @@ add_dependencies(${PROJECT_NAME}
 
 set(LIBS
     ${LIBS}
-    ivi-extension-protocol
     ${WAYLAND_SERVER_LIBRARIES}
     ${WESTON_LIBRARIES}
 )

--- a/ivi-layermanagement-api/ilmClient/CMakeLists.txt
+++ b/ivi-layermanagement-api/ilmClient/CMakeLists.txt
@@ -25,12 +25,31 @@ find_package(Threads)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
 
+find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
+
+add_custom_command(
+    OUTPUT  ivi-application-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-client-protocol.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+)
+
+add_custom_command(
+    OUTPUT  ivi-application-protocol.c
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-protocol.c
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+)
+
 GET_TARGET_PROPERTY(ILM_COMMON_INCLUDE_DIRS ilmCommon INCLUDE_DIRECTORIES)
 
 include_directories(
     include
     ${ILM_COMMON_INCLUDE_DIRS}
     ${WAYLAND_CLIENT_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 link_directories(
@@ -40,11 +59,12 @@ link_directories(
 add_library(${PROJECT_NAME} SHARED
     src/ilm_client.c
     src/ilm_client_wayland_platform.c
+    ivi-application-protocol.c
+    ivi-application-client-protocol.h
 )
 
 set(LIBS
     ${LIBS}
-    ivi-extension-protocol
     ${WAYLAND_CLIENT_LIBRARIES}
 )
 

--- a/ivi-layermanagement-api/ilmCommon/CMakeLists.txt
+++ b/ivi-layermanagement-api/ilmCommon/CMakeLists.txt
@@ -26,11 +26,8 @@ find_package(Threads)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
 
-GET_TARGET_PROPERTY(IVI_EXTENSION_INCLUDE_DIRS ivi-extension-protocol INCLUDE_DIRECTORIES)
-
 include_directories(
     include
-    ${IVI_EXTENSION_INCLUDE_DIRS}
     ${WAYLAND_CLIENT_INCLUDE_DIRS}
 )
 
@@ -49,7 +46,6 @@ target_link_libraries(${PROJECT_NAME}
 
 add_dependencies(${PROJECT_NAME}
     ${WAYLAND_CLIENT_LIBRARIES}
-    ivi-extension-protocol
 )
 
 install (

--- a/ivi-layermanagement-api/ilmControl/CMakeLists.txt
+++ b/ivi-layermanagement-api/ilmControl/CMakeLists.txt
@@ -28,10 +28,45 @@ pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
 
 GET_TARGET_PROPERTY(ILM_COMMON_INCLUDE_DIRS ilmCommon INCLUDE_DIRECTORIES)
 
+find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
+
+add_custom_command(
+    OUTPUT  ivi-wm-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-wm-client-protocol.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
+)
+
+add_custom_command(
+    OUTPUT  ivi-wm-protocol.c
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-wm-protocol.c
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
+)
+
+add_custom_command(
+    OUTPUT  ivi-input-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-input-client-protocol.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
+)
+
+add_custom_command(
+    OUTPUT  ivi-input-protocol.c
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-input-protocol.c
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
+)
+
 include_directories(
     include
     ${ILM_COMMON_INCLUDE_DIRS}
     ${WAYLAND_CLIENT_INCLUDE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 link_directories(
@@ -41,6 +76,10 @@ link_directories(
 add_library(${PROJECT_NAME} SHARED
     src/ilm_control_wayland_platform.c
     src/bitmap.c
+    ivi-wm-client-protocol.h
+    ivi-wm-protocol.c
+    ivi-input-client-protocol.h
+    ivi-input-protocol.c
 )
 
 add_dependencies(${PROJECT_NAME}
@@ -51,7 +90,6 @@ add_dependencies(${PROJECT_NAME}
 set(LIBS
     ${LIBS}
     ilmCommon
-    ivi-extension-protocol
     rt
     dl
     ${CMAKE_THREAD_LIBS_INIT}

--- a/ivi-layermanagement-examples/EGLWLInputEventExample/CMakeLists.txt
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/CMakeLists.txt
@@ -29,16 +29,32 @@ pkg_check_modules(WAYLAND_EGL wayland-egl REQUIRED)
 pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
 pkg_check_modules(WAYLAND_CURSOR wayland-cursor REQUIRED)
 
-GET_TARGET_PROPERTY(ILM_CLIENT_INCLUDE_DIRS  ilmClient  INCLUDE_DIRECTORIES)
+find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
+
+add_custom_command(
+    OUTPUT  ivi-application-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-client-protocol.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+)
+
+add_custom_command(
+    OUTPUT  ivi-application-protocol.c
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-protocol.c
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+)
 
 include_directories(
-    ${ILM_CLIENT_INCLUDE_DIRS}
     ${GLESv2_INCLUDE_DIR}
     ${EGL_INCLUDE_DIR}
     ${WAYLAND_CLIENT_INCLUDE_DIR}
     ${WAYLAND_CURSOR_INCLUDE_DIR}
     ${FFI_INCLUDE_DIR}
     "include"
+    ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 link_directories(
@@ -68,14 +84,15 @@ set (SRC_FILES
 
 add_executable(EGLWLInputEventExample
     ${SRC_FILES}
+    ivi-application-protocol.c
     ${HEADER_FILES}
+    ivi-application-client-protocol.h
 )
 
 add_dependencies(EGLWLInputEventExample
     wayland-client
     wayland-cursor
     wayland-egl
-    ivi-application
     ${LIBS}
 )
 
@@ -87,7 +104,6 @@ set(LIBS
     ${WAYLAND_EGL_LIBRARIES}
     ${FFI_LIBRARIES}
     ${EGL_LIBRARIES}
-    ivi-application
 )
 
 add_definitions(${EGL_CFLAGS})

--- a/ivi-layermanagement-examples/EGLWLMockNavigation/CMakeLists.txt
+++ b/ivi-layermanagement-examples/EGLWLMockNavigation/CMakeLists.txt
@@ -28,11 +28,27 @@ pkg_check_modules(EGL egl REQUIRED)
 pkg_check_modules(WAYLAND_EGL wayland-egl REQUIRED)
 pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
 
-GET_TARGET_PROPERTY(ILM_CLIENT_INCLUDE_DIRS  ilmClient  INCLUDE_DIRECTORIES)
+find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
+
+add_custom_command(
+    OUTPUT  ivi-application-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-client-protocol.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+)
+
+add_custom_command(
+    OUTPUT  ivi-application-protocol.c
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-protocol.c
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+)
 
 include_directories(
     include
-    ${ILM_CLIENT_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_BINARY_DIR}
     ${GLESv2_INCLUDE_DIRS}
     ${EGL_INCLUDE_DIRS}
     ${WAYLAND_CLIENT_INCLUDE_DIRS}
@@ -76,7 +92,9 @@ set (SRC_FILES
 
 add_executable(${PROJECT_NAME}
     ${SRC_FILES}
+    ivi-application-protocol.c
     ${HEADER_FILES}
+    ivi-application-client-protocol.h
 )
 
 
@@ -86,7 +104,6 @@ set(LIBS
     ${WAYLAND_CLIENT_LIBRARIES}
     ${WAYLAND_EGL_LIBRARIES}
     ${EGL_LIBRARIES}
-    ivi-application
 )
 
 add_dependencies(${PROJECT_NAME}

--- a/ivi-layermanagement-examples/multi-touch-viewer/CMakeLists.txt
+++ b/ivi-layermanagement-examples/multi-touch-viewer/CMakeLists.txt
@@ -35,11 +35,25 @@ pkg_check_modules(EGL egl REQUIRED)
 pkg_check_modules(WAYLAND_EGL wayland-egl REQUIRED)
 pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
 
-GET_TARGET_PROPERTY(IVI_EXTENSION_PROTOCOL_DIRS ivi-extension-protocol INCLUDE_DIRECTORIES)
+add_custom_command(
+    OUTPUT  ivi-application-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-client-protocol.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+)
+
+add_custom_command(
+    OUTPUT  ivi-application-protocol.c
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-protocol.c
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+)
 
 include_directories(
     include
-    ${IVI_EXTENSION_PROTOCOL_DIRS}
+    ${CMAKE_CURRENT_BINARY_DIR}
     ${GLESv2_INCLUDE_DIRS}
     ${EGL_INCLUDE_DIRS}
     ${WAYLAND_CLIENT_INCLUDE_DIR}
@@ -53,7 +67,6 @@ link_directories(
 
 SET(LIBS
     ${LIBS}
-    ivi-extension-protocol
     ${GLESv2_LIBRARIES}
     ${WAYLAND_CLIENT_LIBRARIES}
     ${WAYLAND_EGL_LIBRARIES}
@@ -75,6 +88,8 @@ set(HEADER_FILES
 
 add_executable(${PROJECT_NAME}
                ${SRC_FILES}
+               ivi-application-protocol.c
+               ivi-application-client-protocol.h
 )
 
 add_dependencies(${PROJECT_NAME} ${LIBS})

--- a/ivi-layermanagement-examples/simple-ivi-share/CMakeLists.txt
+++ b/ivi-layermanagement-examples/simple-ivi-share/CMakeLists.txt
@@ -35,11 +35,41 @@ pkg_check_modules(EGL egl REQUIRED)
 pkg_check_modules(WAYLAND_EGL wayland-egl REQUIRED)
 pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
 
-GET_TARGET_PROPERTY(IVI_EXTENSION_PROTOCOL_DIRS ivi-extension-protocol INCLUDE_DIRECTORIES)
+add_custom_command(
+    OUTPUT  ivi-application-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-client-protocol.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+)
+
+add_custom_command(
+    OUTPUT  ivi-application-protocol.c
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-protocol.c
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+)
+
+add_custom_command(
+    OUTPUT  ivi-share-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-share.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-share-client-protocol.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-share.xml
+)
+
+add_custom_command(
+    OUTPUT  ivi-share-protocol.c
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-share.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-share-protocol.c
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-share.xml
+)
 
 include_directories(
     include
-    ${IVI_EXTENSION_PROTOCOL_DIRS}
+    ${CMAKE_CURRENT_BINARY_DIR}
     ${GLESv2_INCLUDE_DIRS}
     ${EGL_INCLUDE_DIRS}
     ${WAYLAND_CLIENT_INCLUDE_DIR}
@@ -53,7 +83,6 @@ link_directories(
 
 SET(LIBS
     ${LIBS}
-    ivi-extension-protocol
     ${GLESv2_LIBRARIES}
     ${WAYLAND_CLIENT_LIBRARIES}
     ${WAYLAND_EGL_LIBRARIES}
@@ -63,6 +92,10 @@ SET(LIBS
 
 SET(SRC_FILES
     src/simple-ivi-share.c
+    ivi-application-client-protocol.h
+    ivi-application-protocol.c
+    ivi-share-client-protocol.h
+    ivi-share-protocol.c
 )
 
 add_executable(${PROJECT_NAME}

--- a/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
+++ b/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
@@ -23,12 +23,28 @@ find_package(PkgConfig)
 pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
 pkg_check_modules(WAYLAND_CURSOR wayland-cursor REQUIRED)
 
-GET_TARGET_PROPERTY(IVI_EXTENSION_PROTOCOL_DIRS ivi-extension-protocol INCLUDE_DIRECTORIES)
+find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
+
+add_custom_command(
+    OUTPUT  ivi-application-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-client-protocol.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+)
+
+add_custom_command(
+    OUTPUT  ivi-application-protocol.c
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-protocol.c
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
+)
 
 include_directories(
-    ${IVI_EXTENSION_PROTOCOL_DIRS}
     ${WAYLAND_CLIENT_INCLUDE_DIR}
     ${WAYLAND_CURSOR_INCLUDE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 link_directories(
@@ -37,13 +53,14 @@ link_directories(
 )
 
 SET(LIBS
-    ivi-application
     ${WAYLAND_CLIENT_LIBRARIES}
     ${WAYLAND_CURSOR_LIBRARIES}
 )
 
 SET(SRC_FILES
     src/simple-weston-client.c
+    ivi-application-protocol.c
+    ivi-application-client-protocol.h
 )
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})

--- a/protocol/CMakeLists.txt
+++ b/protocol/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 cmake_minimum_required (VERSION 2.6)
 
-project(ivi-extension-protocol)
+project (ivi-application)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(WAYLAND_CLIENT wayland-client>=1.13.0 REQUIRED)
@@ -51,77 +51,6 @@ add_custom_command(
     DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
 )
 
-add_custom_command(
-    OUTPUT  ivi-wm-client-protocol.h
-    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
-            < ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
-            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-wm-client-protocol.h
-    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
-)
-
-add_custom_command(
-    OUTPUT  ivi-wm-server-protocol.h
-    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} server-header
-            < ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
-            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-wm-server-protocol.h
-    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
-)
-
-add_custom_command(
-    OUTPUT  ivi-wm-protocol.c
-    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
-            < ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
-            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-wm-protocol.c
-    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
-)
-
-add_custom_command(
-    OUTPUT  ivi-input-client-protocol.h
-    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
-            < ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
-            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-input-client-protocol.h
-    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
-)
-
-add_custom_command(
-    OUTPUT  ivi-input-server-protocol.h
-    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} server-header
-            < ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
-            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-input-server-protocol.h
-    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
-)
-
-add_custom_command(
-    OUTPUT  ivi-input-protocol.c
-    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
-            < ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
-            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-input-protocol.c
-    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-input.xml
-)
-
-add_custom_command(
-    OUTPUT  ivi-share-client-protocol.h
-    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
-            < ${CMAKE_SOURCE_DIR}/protocol/ivi-share.xml
-            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-share-client-protocol.h
-    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-share.xml
-)
-
-add_custom_command(
-    OUTPUT  ivi-share-server-protocol.h
-    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} server-header
-            < ${CMAKE_SOURCE_DIR}/protocol/ivi-share.xml
-            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-share-server-protocol.h
-    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-share.xml
-)
-
-add_custom_command(
-    OUTPUT  ivi-share-protocol.c
-    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
-            < ${CMAKE_SOURCE_DIR}/protocol/ivi-share.xml
-            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-share-protocol.c
-    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-share.xml
-)
 
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
@@ -134,31 +63,13 @@ link_directories(
     ${WAYLAND_SERVER_LIBRARY_DIRS}
 )
 
-add_library(${PROJECT_NAME} STATIC
-    ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-client-protocol.h
-    ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-server-protocol.h
-    ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-protocol.c
-    ${CMAKE_CURRENT_BINARY_DIR}/ivi-wm-client-protocol.h
-    ${CMAKE_CURRENT_BINARY_DIR}/ivi-wm-server-protocol.h
-    ${CMAKE_CURRENT_BINARY_DIR}/ivi-wm-protocol.c
-    ${CMAKE_CURRENT_BINARY_DIR}/ivi-input-client-protocol.h
-    ${CMAKE_CURRENT_BINARY_DIR}/ivi-input-server-protocol.h
-    ${CMAKE_CURRENT_BINARY_DIR}/ivi-input-protocol.c
-    ${CMAKE_CURRENT_BINARY_DIR}/ivi-share-client-protocol.h
-    ${CMAKE_CURRENT_BINARY_DIR}/ivi-share-server-protocol.h
-    ${CMAKE_CURRENT_BINARY_DIR}/ivi-share-protocol.c
-)
-
-set_target_properties(${PROJECT_NAME} PROPERTIES
-                      COMPILE_FLAGS "-fPIC")
-
-
-project (ivi-application)
-
 add_library(${PROJECT_NAME} SHARED
     ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-client-protocol.h
     ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-protocol.c
 )
+
+set_target_properties(${PROJECT_NAME} PROPERTIES
+                      COMPILE_FLAGS "-fPIC")
 
 install(
     TARGETS ${PROJECT_NAME}

--- a/weston-ivi-shell/CMakeLists.txt
+++ b/weston-ivi-shell/CMakeLists.txt
@@ -27,6 +27,40 @@ pkg_check_modules(WAYLAND_SERVER wayland-server>=1.13.0 REQUIRED)
 pkg_check_modules(WESTON weston>=2.0.0 REQUIRED)
 pkg_check_modules(PIXMAN pixman-1 REQUIRED)
 
+find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
+
+add_custom_command(
+    OUTPUT  ivi-wm-server-protocol.h
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} server-header
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-wm-server-protocol.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
+)
+
+add_custom_command(
+    OUTPUT  ivi-wm-protocol.c
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-wm-protocol.c
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-wm.xml
+)
+
+add_custom_command(
+    OUTPUT  ivi-share-server-protocol.h
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} server-header
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-share.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-share-server-protocol.h
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-share.xml
+)
+
+add_custom_command(
+    OUTPUT  ivi-share-protocol.c
+    COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+            < ${CMAKE_SOURCE_DIR}/protocol/ivi-share.xml
+            > ${CMAKE_CURRENT_BINARY_DIR}/ivi-share-protocol.c
+    DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-share.xml
+)
+
 find_package(Threads REQUIRED)
 if (IVI_SHARE)
     pkg_check_modules(GBM gbm REQUIRED)
@@ -35,6 +69,8 @@ if (IVI_SHARE)
     SET(BUFFER_SHARING_SRC_FILES
         src/ivi-share.c
         src/ivi-share-gbm.c
+        ivi-share-protocol.c
+        ivi-share-server-protocol.h
     )
 endif (IVI_SHARE)
 
@@ -44,12 +80,9 @@ CHECK_FUNCTION_EXISTS(posix_fallocate HAVE_POSIX_FALLOCATE)
 
 configure_file(src/config.h.cmake config.h)
 
-GET_TARGET_PROPERTY(IVI_EXTENSION_INCLUDE_DIRS ivi-extension-protocol INCLUDE_DIRECTORIES)
-
 include_directories(
     src
     ${CMAKE_CURRENT_BINARY_DIR}
-    ${IVI_EXTENSION_INCLUDE_DIRS}
     ${WAYLAND_SERVER_INCLUDE_DIRS}
     ${WESTON_INCLUDE_DIRS}
     ${PIXMAN_INCLUDE_DIRS}
@@ -63,20 +96,20 @@ link_directories(
 
 add_library(${PROJECT_NAME} MODULE
     src/ivi-controller.c
+    ivi-wm-protocol.c
+    ivi-wm-server-protocol.h
     ${BUFFER_SHARING_SRC_FILES}
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
 
 add_dependencies(${PROJECT_NAME}
-    ivi-extension-protocol
     ${WAYLAND_SERVER_LIBRARIES}
     ${PIXMAN_LIBRARIES}
 )
 
 set(LIBS
     ${LIBS}
-    ivi-extension-protocol
     ${WAYLAND_SERVER_LIBRARIES}
 )
 


### PR DESCRIPTION
Currently, all wayland protocol files are generated once in protocol folder and compiled to a static library, which is called libivi-extension-protocol.a. Then, this static library is linked to the every library which uses wayland protocol files.  But these libraries are using actually not all of the protocol files, which are linked into ivi-extension-protocol. Therefore, size of libraries increases unnecessarily.

I removed this static library. Now every library generates wayland protocol files with wayland-scanner. Only needed protocol files are linked into the binaries.