### PR TITLE
fix wrong fprintf usage

### DIFF
--- a/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
+++ b/ivi-layermanagement-api/ilmControl/src/ilm_control_wayland_platform.c
@@ -374,7 +374,7 @@ wm_listener_layer_error(void *data, struct ivi_wm *controller, uint32_t object_i
         error_code = ILM_ERROR_ON_CONNECTION;
     }
 
-    fprintf(stderr, message);
+    fprintf(stderr, "%s", message);
     fprintf(stderr, "\n");
 
     /*Do not override old error message*/
@@ -597,7 +597,7 @@ wm_listener_surface_error(void *data, struct ivi_wm *controller,
         break;
     }
 
-    fprintf(stderr, message);
+    fprintf(stderr, "%s", message);
     fprintf(stderr, "\n");
 
     if (ctx->error_flag == ILM_SUCCESS)
@@ -683,7 +683,7 @@ wm_screen_listener_error(void *data, struct ivi_wm_screen *controller,
         break;
     }
 
-    fprintf(stderr, message);
+    fprintf(stderr, "%s", message);
     fprintf(stderr, "\n");
 
     if (ctx_screen->ctx->error_flag == ILM_SUCCESS)


### PR DESCRIPTION
Change-Id: Ibf895036223cbbac03d614d6552f3a146f587f05
Signed-off-by: Romain Forlot <romain.forlot@iot.bzh>