### PR TITLE
Clean ivi share

### DIFF
--- a/weston-ivi-shell/src/ivi-share-gbm.c
+++ b/weston-ivi-shell/src/ivi-share-gbm.c
@@ -33,8 +33,6 @@
 #include "ivi-share-server-protocol.h"
 #include "ivi-share.h"
 
-static uint32_t nativesurface_name;
-
 /* copied from libinput-seat.h of weston-1.9.0 */
 struct udev_input {
 	struct libinput *libinput;
@@ -92,16 +90,13 @@ struct drm_backend {
 };
 
 uint32_t
-get_buffer_name(struct weston_surface *surface,
-                struct ivi_shell_share_ext *shell_ext)
+get_buffer_name(struct ivi_share_nativesurface *p_nativesurface)
 {
-     (void)surface;
-     return nativesurface_name;
+     return p_nativesurface->name;
 }
 
 uint32_t
-update_buffer_nativesurface(struct ivi_share_nativesurface *p_nativesurface,
-                            struct ivi_shell_share_ext *shell_ext)
+update_buffer_nativesurface(struct ivi_share_nativesurface *p_nativesurface)
 {
     if (NULL == p_nativesurface || NULL == p_nativesurface->surface) {
         return IVI_SHAREBUFFER_NOT_AVAILABLE;
@@ -139,8 +134,6 @@ update_buffer_nativesurface(struct ivi_share_nativesurface *p_nativesurface,
     uint32_t stride = gbm_bo_get_stride(bo);
     uint32_t format = IVI_SHARE_SURFACE_FORMAT_ARGB8888;
     uint32_t ret    = IVI_SHAREBUFFER_STABLE;
-
-    nativesurface_name = name;
 
     if (name != p_nativesurface->name) {
         ret |= IVI_SHAREBUFFER_DAMAGE;

--- a/weston-ivi-shell/src/ivi-share.c
+++ b/weston-ivi-shell/src/ivi-share.c
@@ -345,7 +345,7 @@ alloc_share_nativesurface(struct weston_surface *surface, uint32_t id, uint32_t 
                           struct ivi_shell_share_ext *shell_ext)
 {
     struct ivi_share_nativesurface *nativesurface =
-        malloc(sizeof(struct ivi_share_nativesurface));
+        calloc(1, sizeof(struct ivi_share_nativesurface));
     if (NULL == nativesurface) {
         return NULL;
     }
@@ -353,10 +353,6 @@ alloc_share_nativesurface(struct weston_surface *surface, uint32_t id, uint32_t 
     nativesurface->id = id;
     nativesurface->surface = surface;
     nativesurface->bufferType = bufferType;
-    nativesurface->name = 0;
-    nativesurface->width = 0;
-    nativesurface->height = 0;
-    nativesurface->stride = 0;
     nativesurface->format = format;
     nativesurface->surface_id = surface_id;
     nativesurface->shell_ext = shell_ext;

--- a/weston-ivi-shell/src/ivi-share.c
+++ b/weston-ivi-shell/src/ivi-share.c
@@ -593,8 +593,7 @@ bind_share_interface(struct wl_client *p_client, void *p_data,
 }
 
 static void
-send_to_client(struct ivi_share_nativesurface *p_nativesurface, uint32_t send_flag,
-               struct ivi_shell_share_ext *shell_ext)
+send_to_client(struct ivi_share_nativesurface *p_nativesurface, uint32_t send_flag)
 {
     struct ivi_share_nativesurface_client_link *p_link = NULL;
 
@@ -621,7 +620,7 @@ send_to_client(struct ivi_share_nativesurface *p_nativesurface, uint32_t send_fl
         }
         if ((IVI_SHAREBUFFER_DAMAGE & send_flag) == IVI_SHAREBUFFER_DAMAGE) {
             send_damage(p_link->resource, p_nativesurface->id,
-                        get_buffer_name(p_nativesurface->surface, shell_ext));
+                        get_buffer_name(p_nativesurface));
         }
     }
 }
@@ -652,8 +651,8 @@ send_nativesurface_event(struct wl_listener *listener, void *data)
             continue;
         }
 
-        p_nativesurface->send_flag = update_buffer_nativesurface(p_nativesurface, shell_ext);
-        send_to_client(p_nativesurface, p_nativesurface->send_flag, shell_ext);
+        p_nativesurface->send_flag = update_buffer_nativesurface(p_nativesurface);
+        send_to_client(p_nativesurface, p_nativesurface->send_flag);
     }
 }
 

--- a/weston-ivi-shell/src/ivi-share.h
+++ b/weston-ivi-shell/src/ivi-share.h
@@ -69,7 +69,5 @@ enum ivi_sharebuffer_updatetype
 int32_t setup_buffer_sharing(struct weston_compositor *wc,
                              const struct ivi_layout_interface *interface);
 
-uint32_t get_buffer_name(struct weston_surface *surface,
-                         struct ivi_shell_share_ext *shell_ext);
-uint32_t update_buffer_nativesurface(struct ivi_share_nativesurface *nativesurface,
-                                     struct ivi_shell_share_ext *shell_ext);
+uint32_t get_buffer_name(struct ivi_share_nativesurface *p_nativesurface);
+uint32_t update_buffer_nativesurface(struct ivi_share_nativesurface *p_nativesurface);


### PR DESCRIPTION
These patches are preparations for introducing the release_shared_name request.
It has been changed based on these patches.