### PR TITLE
 ivi-share: introduce release_shared_name request

### DIFF
--- a/ivi-layermanagement-examples/simple-ivi-share/src/simple-ivi-share.c
+++ b/ivi-layermanagement-examples/simple-ivi-share/src/simple-ivi-share.c
@@ -185,6 +185,7 @@ handle_share_surface_damage(void *data, struct ivi_share_surface *share_surface,
         if (window->share_buffer.eglimage != NULL) {
             pfEglDestroyImageKHR(display->egl.egldisplay,
                                  window->share_buffer.eglimage);
+            ivi_share_surface_release_shared_name(window->share_surface, window->share_buffer.name);
         }
 
         window->share_buffer.eglimage =
@@ -580,7 +581,7 @@ registry_handle_global(void *data, struct wl_registry *registry,
             wl_registry_bind(registry, name, &ivi_application_interface, 1);
     } else if (strcmp(interface, "ivi_share") == 0) {
         display->ivi_share =
-            wl_registry_bind(registry, name, &ivi_share_interface, 1);
+            wl_registry_bind(registry, name, &ivi_share_interface, 2);
     } else if (strcmp(interface, "wl_seat") == 0) {
         display->seat =
             wl_registry_bind(registry, name, &wl_seat_interface, 1);

--- a/protocol/ivi-share.xml
+++ b/protocol/ivi-share.xml
@@ -2,7 +2,7 @@
 <protocol name="ivi_share">
 
     <copyright>
-        Copyright (c) 2012 Advanced Driver Information Technology.
+        Copyright (c) 2012-2017 Advanced Driver Information Technology.
 
         Permission is hereby granted, free of charge, to any person obtaining a copy
         of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,7 @@
         THE SOFTWARE.
     </copyright>
 
-    <interface name="ivi_share" version="1">
+    <interface name="ivi_share" version="2">
         <description summary="get handle to manipulate ivi_surface">
           get handle ID to manipulate shared ivi_surface. The host ivi application
           can get trigger of update of the ivi_surface from client to draw it in host's
@@ -37,7 +37,7 @@
         </request>
     </interface>
 
-    <interface name="ivi_share_surface" version="1">
+    <interface name="ivi_share_surface" version="2">
         <description summary="extension interface for sharing a ivi_surface">
         </description>
 
@@ -135,5 +135,15 @@
             <description summary="state of shared surface"/>
             <arg name="state" type="uint"/>
         </event>
+
+        <!-- Version 2 additions -->
+
+        <request name="release_shared_name" since="2">
+            <description summary="consumer releases shared name">
+              Send when the consumer no longer uses the share name notified by the damage event.
+              Until the consumer notifies the release, the compositor will not release the buffer to the producer.
+            </description>
+            <arg name="name" type="uint"/>
+        </request>
     </interface>
 </protocol>

--- a/weston-ivi-shell/src/ivi-share.h
+++ b/weston-ivi-shell/src/ivi-share.h
@@ -28,6 +28,16 @@
  */
 #define IVI_BIT(x) (1 << (x))
 
+#define MAX_BUFFER_REFERENCE 2
+
+struct ivi_share_buffer_reference
+{
+	struct weston_buffer_reference ref;
+	uint32_t name;
+	uint32_t client_count;
+	bool next_to_release;
+};
+
 struct ivi_share_nativesurface
 {
     struct weston_surface *surface; /* resource                                   */
@@ -44,6 +54,7 @@ struct ivi_share_nativesurface
     uint32_t send_flag;
     struct wl_listener surface_destroy_listener;
     struct ivi_shell_share_ext *shell_ext;
+    struct ivi_share_buffer_reference buffer_refs[MAX_BUFFER_REFERENCE];
 };
 
 struct ivi_shell_share_ext


### PR DESCRIPTION
The compositor was unable to know whether shared buffers no longer needed.
Therefore, in spite of the consumer still using the buffer, the compositor was releasing the buffer to the producer.
In order to solve this problem, the request is introduced.