### PR TITLE
ivi-share: add missing return value in setup_buffer_sharing()

### DIFF
--- a/weston-ivi-shell/src/ivi-share.c
+++ b/weston-ivi-shell/src/ivi-share.c
@@ -853,4 +853,5 @@ setup_buffer_sharing(struct weston_compositor *wc,
 
     shell_ext->surface_created_listener.notify = add_weston_surf_data;
     wl_signal_add(&wc->create_surface_signal, &shell_ext->surface_created_listener);
+    return 0;
 }


### PR DESCRIPTION
otherwise weston might randomly fail to init the module