### PR TITLE
EGLWLInputEventExample: exit when wayland error occurs

### DIFF
--- a/ivi-layermanagement-examples/EGLWLInputEventExample/include/WLEyesRenderer.h
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/include/WLEyesRenderer.h
@@ -27,7 +27,7 @@
 bool InitRenderer();
 bool InitShader();
 bool InitVertexBuffer();
-void WaitForEvent(struct wl_display* wlDisplay, int fd);
+int WaitForEvent(struct wl_display* wlDisplay, int fd);
 void TerminateRenderer();
 
 // Pointer event handler

--- a/ivi-layermanagement-examples/EGLWLInputEventExample/src/WLEyesRenderer.cpp
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/src/WLEyesRenderer.cpp
@@ -57,7 +57,7 @@ const struct wl_touch_listener TouchListener = {
     TouchHandleCancel,
 };
 
-void WaitForEvent(struct wl_display* wlDisplay, int fd)
+int WaitForEvent(struct wl_display* wlDisplay, int fd)
 {
     int err;
 
@@ -71,7 +71,7 @@ void WaitForEvent(struct wl_display* wlDisplay, int fd)
     {
         err = wl_display_get_error(wlDisplay);
         printf("Error communicating with wayland: %d",err);
-        return;
+        return -1;
     }
 
     /*Wait till an event occurs */
@@ -90,6 +90,8 @@ void WaitForEvent(struct wl_display* wlDisplay, int fd)
         /*Unblock other threads, if an error happens */
         wl_display_cancel_read(wlDisplay);
     }
+
+    return 0;
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/ivi-layermanagement-examples/EGLWLInputEventExample/src/main.cpp
+++ b/ivi-layermanagement-examples/EGLWLInputEventExample/src/main.cpp
@@ -99,7 +99,10 @@ int main(int argc, char **argv)
     gRunLoop = 1;
     gNeedRedraw = 0;
     while (gRunLoop){
-        WaitForEvent(wlContext->GetWLDisplay(), fd);
+        if ((WaitForEvent(wlContext->GetWLDisplay(), fd) < 0)){
+            gRunLoop = 0;
+        }
+
         if (gNeedRedraw && gRunLoop){
             DrawEyes(eglSurface, eyes);
             gNeedRedraw = 0;


### PR DESCRIPTION
there is nothing to do if a wayland error occurs
we should just close the application

Signed-off-by: Emre Ucan <eucan@de.adit-jv.com>