### PR TITLE
Weston debug support

### DIFF
--- a/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
+++ b/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
@@ -22,6 +22,12 @@ project (simple-weston-client)
 find_package(PkgConfig)
 pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
 pkg_check_modules(WAYLAND_CURSOR wayland-cursor REQUIRED)
+pkg_check_modules(LIBWESTON_PROTOCOLS libweston-2-protocols QUIET)
+
+if(${LIBWESTON_PROTOCOLS_FOUND})
+    SET(LIBWESTON_PROTOCOLS_PKGDATADIR "${WAYLAND_PROTOCOLS_SYSROOT_DIR}/${CMAKE_INSTALL_PREFIX}/share/weston/protocols")
+endif(${LIBWESTON_PROTOCOLS_FOUND})
+
 
 find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
 
@@ -40,6 +46,32 @@ add_custom_command(
             > ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-protocol.c
     DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
 )
+
+if(${LIBWESTON_PROTOCOLS_FOUND})
+    add_custom_command(
+        OUTPUT  weston-debug-client-protocol.h
+        COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
+                < ${LIBWESTON_PROTOCOLS_PKGDATADIR}/weston-debug.xml
+                > ${CMAKE_CURRENT_BINARY_DIR}/weston-debug-client-protocol.h
+        DEPENDS ${LIBWESTON_PROTOCOLS_PKGDATADIR}/weston-debug.xml
+    )
+
+    add_custom_command(
+        OUTPUT  weston-debug-server-protocol.h
+        COMMAND ${WAYLAND_SCANNER_EXECUTABLE} server-header
+                < ${LIBWESTON_PROTOCOLS_PKGDATADIR}/weston-debug.xml
+                > ${CMAKE_CURRENT_BINARY_DIR}/weston-debug-server-protocol.h
+        DEPENDS ${LIBWESTON_PROTOCOLS_PKGDATADIR}/weston-debug.xml
+    )
+
+    add_custom_command(
+        OUTPUT  weston-debug-protocol.c
+        COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+                < ${LIBWESTON_PROTOCOLS_PKGDATADIR}/weston-debug.xml
+                > ${CMAKE_CURRENT_BINARY_DIR}/weston-debug-protocol.c
+        DEPENDS ${LIBWESTON_PROTOCOLS_PKGDATADIR}/weston-debug.xml
+    )
+endif(${LIBWESTON_PROTOCOLS_FOUND})
 
 include_directories(
     ${WAYLAND_CLIENT_INCLUDE_DIR}
@@ -63,7 +95,15 @@ SET(SRC_FILES
     ivi-application-client-protocol.h
 )
 
-add_executable(${PROJECT_NAME} ${SRC_FILES})
+if(${LIBWESTON_PROTOCOLS_FOUND})
+    SET(WESTON_DEBUG_SRC_FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/weston-debug-protocol.c
+        ${CMAKE_CURRENT_BINARY_DIR}/weston-debug-client-protocol.h
+        ${CMAKE_CURRENT_BINARY_DIR}/weston-debug-server-protocol.h
+)
+endif(${LIBWESTON_PROTOCOLS_FOUND})
+
+add_executable(${PROJECT_NAME} ${SRC_FILES} ${WESTON_DEBUG_SRC_FILES})
 
 add_dependencies(${PROJECT_NAME} ${LIBS})
 

--- a/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
+++ b/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
@@ -115,6 +115,7 @@ add_dependencies(${PROJECT_NAME} ${LIBS})
 
 if(${LIBWESTON_PROTOCOLS_FOUND})
     add_definitions(${DLT_CFLAGS})
+    add_definitions(-DLIBWESTON_DEBUG_PROTOCOL)
 endif(${LIBWESTON_PROTOCOLS_FOUND})
 
 target_link_libraries(${PROJECT_NAME} ${LIBS})

--- a/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
+++ b/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
@@ -23,6 +23,9 @@ find_package(PkgConfig)
 pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
 pkg_check_modules(WAYLAND_CURSOR wayland-cursor REQUIRED)
 pkg_check_modules(LIBWESTON_PROTOCOLS libweston-2-protocols QUIET)
+if(${LIBWESTON_PROTOCOLS_FOUND})
+    pkg_check_modules(DLT automotive-dlt REQUIRED)
+endif(${LIBWESTON_PROTOCOLS_FOUND})
 
 if(${LIBWESTON_PROTOCOLS_FOUND})
     SET(LIBWESTON_PROTOCOLS_PKGDATADIR "${WAYLAND_PROTOCOLS_SYSROOT_DIR}/${CMAKE_INSTALL_PREFIX}/share/weston/protocols")
@@ -77,16 +80,19 @@ include_directories(
     ${WAYLAND_CLIENT_INCLUDE_DIR}
     ${WAYLAND_CURSOR_INCLUDE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
+    ${DLT_INCLUDE_DIR}
 )
 
 link_directories(
     ${WAYLAND_CLIENT_LIBRARY_DIRS}
     ${WAYLAND_CURSOR_LIBRARY_DIRS}
+    ${DLT_LIBRARY_DIRS}
 )
 
 SET(LIBS
     ${WAYLAND_CLIENT_LIBRARIES}
     ${WAYLAND_CURSOR_LIBRARIES}
+    ${DLT_LIBRARIES}
 )
 
 SET(SRC_FILES
@@ -106,6 +112,10 @@ endif(${LIBWESTON_PROTOCOLS_FOUND})
 add_executable(${PROJECT_NAME} ${SRC_FILES} ${WESTON_DEBUG_SRC_FILES})
 
 add_dependencies(${PROJECT_NAME} ${LIBS})
+
+if(${LIBWESTON_PROTOCOLS_FOUND})
+    add_definitions(${DLT_CFLAGS})
+endif(${LIBWESTON_PROTOCOLS_FOUND})
 
 target_link_libraries(${PROJECT_NAME} ${LIBS})
 

--- a/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
+++ b/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
@@ -107,15 +107,15 @@ get_bkgnd_settings(void)
     char *end;
     int len;
 
+    /*if no environment variable given return NULL*/
+    option = getenv("IVI_CLIENT_SURFACE_ID");
+    if(NULL == option)
+        return NULL;
+
     bkgnd_settings =
             (BkGndSettingsStruct*)calloc(1, sizeof(BkGndSettingsStruct));
 
-    option = getenv("IVI_CLIENT_SURFACE_ID");
-    if(option)
-        bkgnd_settings->surface_id = strtol(option, &end, 0);
-    else
-        bkgnd_settings->surface_id = 10;
-
+    bkgnd_settings->surface_id = strtol(option, &end, 0);
     bkgnd_settings->surface_width = 1;
     bkgnd_settings->surface_height = 1;
     bkgnd_settings->surface_stride = bkgnd_settings->surface_width * 4;
@@ -383,24 +383,32 @@ registry_handle_global(void *data, struct wl_registry *registry, uint32_t name,
     WaylandContextStruct* wlcontext = (WaylandContextStruct*)data;
 
     if (!strcmp(interface, "wl_compositor")) {
-        wlcontext->wl_compositor =
-                wl_registry_bind(registry, name,
-                                 &wl_compositor_interface, 1);
+        if (wlcontext->bkgnd_settings) {
+            wlcontext->wl_compositor =
+                    wl_registry_bind(registry, name,
+                                     &wl_compositor_interface, 1);
+        }
     }
     else if (!strcmp(interface, "wl_shm")) {
-        wlcontext->wl_shm =
-                wl_registry_bind(registry, name, &wl_shm_interface, 1);
-        wl_shm_add_listener(wlcontext->wl_shm, &shm_listenter, wlcontext);
+        if (wlcontext->bkgnd_settings) {
+            wlcontext->wl_shm =
+                    wl_registry_bind(registry, name, &wl_shm_interface, 1);
+            wl_shm_add_listener(wlcontext->wl_shm, &shm_listenter, wlcontext);
+        }
     }
     else if (!strcmp(interface, "ivi_application")) {
-        wlcontext->ivi_application =
-                wl_registry_bind(registry, name,
-                                 &ivi_application_interface, 1);
+        if (wlcontext->bkgnd_settings) {
+            wlcontext->ivi_application =
+                    wl_registry_bind(registry, name,
+                                     &ivi_application_interface, 1);
+        }
     }
     else if (!strcmp(interface, "wl_seat")) {
-        wlcontext->wl_seat =
-                wl_registry_bind(registry, name, &wl_seat_interface, 1);
-        wl_seat_add_listener(wlcontext->wl_seat, &seat_Listener, data);
+        if (wlcontext->bkgnd_settings) {
+            wlcontext->wl_seat =
+                    wl_registry_bind(registry, name, &wl_seat_interface, 1);
+            wl_seat_add_listener(wlcontext->wl_seat, &seat_Listener, data);
+        }
     }
     if (!strcmp(interface, weston_debug_v1_interface.name)) {
         uint32_t myver;
@@ -440,14 +448,16 @@ int init_wayland_context(WaylandContextStruct* wlcontext)
                              &registry_listener, wlcontext);
     wl_display_roundtrip(wlcontext->wl_display);
 
-    if (wlcontext->wl_shm == NULL) {
+    if (wlcontext->bkgnd_settings &&
+        (wlcontext->wl_shm == NULL)) {
         fprintf(stderr, "No wl_shm global\n");
         return -1;
     }
 
     wl_display_roundtrip(wlcontext->wl_display);
 
-    if (!(wlcontext->formats & (1 << WL_SHM_FORMAT_XRGB8888))) {
+    if (wlcontext->bkgnd_settings &&
+        !(wlcontext->formats & (1 << WL_SHM_FORMAT_XRGB8888))) {
         fprintf(stderr, "WL_SHM_FORMAT_XRGB32 not available\n");
         return -1;
     }
@@ -460,11 +470,23 @@ void destroy_wayland_context(WaylandContextStruct* wlcontext)
     if(wlcontext->wl_compositor)
         wl_compositor_destroy(wlcontext->wl_compositor);
 
-    if(wlcontext->wl_display)
-        wl_display_disconnect(wlcontext->wl_display);
+    if(wlcontext->ivi_application)
+       ivi_application_destroy(wlcontext->ivi_application);
+
+    if(wlcontext->wl_shm)
+        wl_shm_destroy(wlcontext->wl_shm);
+
+    if(wlcontext->wl_seat)
+        wl_seat_destroy(wlcontext->wl_seat);
 
     if(wlcontext->debug_iface)
         weston_debug_v1_destroy(wlcontext->debug_iface);
+
+    if(wlcontext->wl_registry)
+        wl_registry_destroy(wlcontext->wl_registry);
+
+    if(wlcontext->wl_display)
+        wl_display_disconnect(wlcontext->wl_display);
 }
 
 int
@@ -727,7 +749,7 @@ int main (int argc, const char * argv[])
     sigaction(SIGTERM, &sigint, NULL);
     sigaction(SIGSEGV, &sigint, NULL);
 
-    /*get bkgnd settings and create shm-surface*/
+    /*get bkgnd settings if available*/
     bkgnd_settings = get_bkgnd_settings();
 
     /*init wayland context*/
@@ -744,7 +766,7 @@ int main (int argc, const char * argv[])
         return -1;
     }
 
-    if (create_bkgnd_surface(wlcontext)) {
+    if (wlcontext->bkgnd_settings && create_bkgnd_surface(wlcontext)) {
         fprintf(stderr, "create_bkgnd_surface failed\n");
         goto Error;
     }
@@ -768,7 +790,8 @@ int main (int argc, const char * argv[])
     }
 
     /*draw the bkgnd display*/
-    draw_bkgnd_surface(wlcontext);
+    if (wlcontext->bkgnd_settings)
+        draw_bkgnd_surface(wlcontext);
 
     while (running && (ret != -1))
         ret = display_dispatch(wlcontext->wl_display);
@@ -777,7 +800,8 @@ Error:
     destroy_streams(wlcontext);
     wl_display_roundtrip(wlcontext->wl_display);
 
-    destroy_bkgnd_surface(wlcontext);
+    if (wlcontext->bkgnd_settings)
+        destroy_bkgnd_surface(wlcontext);
     destroy_wayland_context(wlcontext);
 
     if(wlcontext->thread_running)
@@ -789,7 +813,9 @@ Error:
         close(wlcontext->pipefd[0]);
     }
 
-    free(bkgnd_settings);
+    if (bkgnd_settings)
+        free(bkgnd_settings);
+
     free(wlcontext);
 
     return 0;

--- a/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
+++ b/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
@@ -216,6 +216,9 @@ get_debug_streams(WaylandContextStruct* wlcontext)
 
     stream_names = getenv("IVI_CLIENT_DEBUG_STREAM_NAMES");
 
+    if(NULL == stream_names)
+        return;
+
     /* get the first stream */
     stream = strtok(stream_names, separator);
 

--- a/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
+++ b/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
@@ -32,13 +32,22 @@
 #include <signal.h>
 #include <poll.h>
 
-#include "dlt_common.h"
-#include "dlt_user.h"
-
 #include <wayland-cursor.h>
 #include <ivi-application-client-protocol.h>
 
+#ifdef LIBWESTON_DEBUG_PROTOCOL
+#include "dlt_common.h"
+#include "dlt_user.h"
 #include "weston-debug-client-protocol.h"
+
+#define WESTON_DLT_APP_DESC "messages from weston debug protocol"
+#define WESTON_DLT_CONTEXT_DESC "weston debug context"
+
+#define WESTON_DLT_APP "WESN"
+#define WESTON_DLT_CONTEXT "WESC"
+
+#define MAXSTRLEN 1024
+#endif
 
 #ifndef MIN
 #define MIN(x,y) (((x) < (y)) ? (x) : (y))
@@ -60,7 +69,6 @@ typedef struct _WaylandContext {
     struct wl_compositor    *wl_compositor;
     struct wl_shm           *wl_shm;
     struct wl_seat          *wl_seat;
-    struct weston_debug_v1  *debug_iface;
     struct wl_pointer       *wl_pointer;
     struct wl_surface       *wl_pointer_surface;
     struct ivi_application  *ivi_application;
@@ -71,11 +79,14 @@ typedef struct _WaylandContext {
     struct wl_cursor        *cursor;
     void                    *bkgnddata;
     uint32_t                formats;
+#ifdef LIBWESTON_DEBUG_PROTOCOL
+    struct weston_debug_v1  *debug_iface;
     struct wl_list          stream_list;
     int                     debug_fd;
     char                    thread_running;
     pthread_t               dlt_ctx_thread;
     int                     pipefd[2];
+#endif
 }WaylandContextStruct;
 
 struct debug_stream {
@@ -90,14 +101,6 @@ static const char *left_ptrs[] = {
     "top_left_arrow",
     "left-arrow"
 };
-
-#define WESTON_DLT_APP_DESC "messages from weston debug protocol"
-#define WESTON_DLT_CONTEXT_DESC "weston debug context"
-
-#define WESTON_DLT_APP "WESN"
-#define WESTON_DLT_CONTEXT "WESC"
-
-#define MAXSTRLEN 1024
 
 static BkGndSettingsStruct*
 get_bkgnd_settings(void)
@@ -123,6 +126,7 @@ get_bkgnd_settings(void)
     return bkgnd_settings;
 }
 
+#ifdef LIBWESTON_DEBUG_PROTOCOL
 static struct debug_stream *
 stream_alloc(WaylandContextStruct* wlcontext, const char *name)
 {
@@ -228,6 +232,7 @@ get_debug_streams(WaylandContextStruct* wlcontext)
         stream = strtok(NULL, separator);
     }
 }
+#endif
 
 static void
 shm_format(void *data, struct wl_shm *wl_shm, uint32_t format)
@@ -410,7 +415,8 @@ registry_handle_global(void *data, struct wl_registry *registry, uint32_t name,
             wl_seat_add_listener(wlcontext->wl_seat, &seat_Listener, data);
         }
     }
-    if (!strcmp(interface, weston_debug_v1_interface.name)) {
+#ifdef LIBWESTON_DEBUG_PROTOCOL
+    else if (!strcmp(interface, weston_debug_v1_interface.name)) {
         uint32_t myver;
 
         if (wlcontext->debug_iface || wl_list_empty(&wlcontext->stream_list))
@@ -421,6 +427,7 @@ registry_handle_global(void *data, struct wl_registry *registry, uint32_t name,
                 wl_registry_bind(registry, name,
                     &weston_debug_v1_interface, myver);
     }
+#endif
 }
 
 static void
@@ -462,6 +469,14 @@ int init_wayland_context(WaylandContextStruct* wlcontext)
         return -1;
     }
 
+#ifdef LIBWESTON_DEBUG_PROTOCOL
+    if (!wl_list_empty(&wlcontext->stream_list) &&
+        (wlcontext->debug_iface == NULL)) {
+        fprintf(stderr, "WARNING: weston_debug protocol is not available,"
+                " missed enabling --debug option to weston ?\n");
+    }
+#endif
+
     return 0;
 }
 
@@ -479,8 +494,10 @@ void destroy_wayland_context(WaylandContextStruct* wlcontext)
     if(wlcontext->wl_seat)
         wl_seat_destroy(wlcontext->wl_seat);
 
+#ifdef LIBWESTON_DEBUG_PROTOCOL
     if(wlcontext->debug_iface)
         weston_debug_v1_destroy(wlcontext->debug_iface);
+#endif
 
     if(wlcontext->wl_registry)
         wl_registry_destroy(wlcontext->wl_registry);
@@ -626,6 +643,7 @@ void destroy_bkgnd_surface(WaylandContextStruct* wlcontext)
         wl_surface_destroy(wlcontext->wlBkgndSurface);
 }
 
+#ifdef LIBWESTON_DEBUG_PROTOCOL
 static void *
 weston_dlt_thread_function(void *data)
 {
@@ -668,6 +686,7 @@ weston_dlt_thread_function(void *data)
     DLT_UNREGISTER_APP();
     pthread_exit(NULL);
 }
+#endif
 
 static void
 signal_int(int signum)
@@ -757,9 +776,13 @@ int main (int argc, const char * argv[])
     wlcontext->bkgnd_settings = bkgnd_settings;
 
     /*init debug stream list*/
+#ifdef LIBWESTON_DEBUG_PROTOCOL
     wl_list_init(&wlcontext->stream_list);
     get_debug_streams(wlcontext);
     wlcontext->debug_fd = STDOUT_FILENO;
+#else
+    fprintf(stderr, "WARNING: weston_debug protocol is not available\n");
+#endif
 
     if (init_wayland_context(wlcontext)) {
         fprintf(stderr, "init_wayland_context failed\n");
@@ -773,6 +796,7 @@ int main (int argc, const char * argv[])
 
     wl_display_roundtrip(wlcontext->wl_display);
 
+#ifdef LIBWESTON_DEBUG_PROTOCOL
     if (!wl_list_empty(&wlcontext->stream_list) &&
             wlcontext->debug_iface) {
         /* create the pipe b/w stdout and stdin
@@ -788,6 +812,7 @@ int main (int argc, const char * argv[])
                 weston_dlt_thread_function, wlcontext);
         start_streams(wlcontext);
     }
+#endif
 
     /*draw the bkgnd display*/
     if (wlcontext->bkgnd_settings)
@@ -797,12 +822,9 @@ int main (int argc, const char * argv[])
         ret = display_dispatch(wlcontext->wl_display);
 
 Error:
+#ifdef LIBWESTON_DEBUG_PROTOCOL
     destroy_streams(wlcontext);
     wl_display_roundtrip(wlcontext->wl_display);
-
-    if (wlcontext->bkgnd_settings)
-        destroy_bkgnd_surface(wlcontext);
-    destroy_wayland_context(wlcontext);
 
     if(wlcontext->thread_running)
     {
@@ -812,6 +834,11 @@ Error:
         pthread_join(wlcontext->dlt_ctx_thread, NULL);
         close(wlcontext->pipefd[0]);
     }
+#endif
+
+    if (wlcontext->bkgnd_settings)
+        destroy_bkgnd_surface(wlcontext);
+    destroy_wayland_context(wlcontext);
 
     if (bkgnd_settings)
         free(bkgnd_settings);

--- a/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
+++ b/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
@@ -27,9 +27,16 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/mman.h>
+#include <assert.h>
 
 #include <wayland-cursor.h>
 #include <ivi-application-client-protocol.h>
+
+#include "weston-debug-client-protocol.h"
+
+#ifndef MIN
+#define MIN(x,y) (((x) < (y)) ? (x) : (y))
+#endif
 
 typedef struct _BkGndSettings
 {
@@ -45,6 +52,7 @@ typedef struct _WaylandContext {
     struct wl_compositor    *wl_compositor;
     struct wl_shm           *wl_shm;
     struct wl_seat          *wl_seat;
+    struct weston_debug_v1  *debug_iface;
     struct wl_pointer       *wl_pointer;
     struct wl_surface       *wl_pointer_surface;
     struct ivi_application  *ivi_application;
@@ -55,7 +63,15 @@ typedef struct _WaylandContext {
     struct wl_cursor        *cursor;
     void                    *bkgnddata;
     uint32_t                formats;
+    struct wl_list          stream_list;
+    int                     debug_fd;
 }WaylandContextStruct;
+
+struct debug_stream {
+    struct wl_list link;
+    char *name;
+    struct weston_debug_stream_v1 *obj;
+};
 
 static const char *left_ptrs[] = {
     "left_ptr",
@@ -86,6 +102,109 @@ get_bkgnd_settings(void)
     bkgnd_settings->surface_stride = bkgnd_settings->surface_width * 4;
 
     return bkgnd_settings;
+}
+
+static struct debug_stream *
+stream_alloc(WaylandContextStruct* wlcontext, const char *name)
+{
+    struct debug_stream *stream;
+
+    stream = calloc(1, (sizeof *stream));
+    if (!stream)
+        return NULL;
+
+    stream->name = strdup(name);
+    if (!stream->name) {
+        free(stream);
+        return NULL;
+    }
+
+    wl_list_insert(wlcontext->stream_list.prev, &stream->link);
+
+    return stream;
+}
+
+static void
+stream_destroy(struct debug_stream *stream)
+{
+    if (stream->obj)
+        weston_debug_stream_v1_destroy(stream->obj);
+
+    wl_list_remove(&stream->link);
+    free(stream->name);
+    free(stream);
+}
+
+static void
+destroy_streams(WaylandContextStruct* wlcontext)
+{
+    struct debug_stream *stream;
+    struct debug_stream *tmp;
+
+    wl_list_for_each_safe(stream, tmp, &wlcontext->stream_list, link) {
+        stream_destroy(stream);
+    }
+}
+
+static void
+handle_stream_complete(void *data, struct weston_debug_stream_v1 *obj)
+{
+    struct debug_stream *stream = data;
+
+    assert(stream->obj == obj);
+
+    stream_destroy(stream);
+}
+
+static void
+handle_stream_failure(void *data, struct weston_debug_stream_v1 *obj,
+		      const char *msg)
+{
+    struct debug_stream *stream = data;
+
+    assert(stream->obj == obj);
+
+    fprintf(stderr, "Debug stream '%s' aborted: %s\n", stream->name, msg);
+
+    stream_destroy(stream);
+}
+
+static const struct weston_debug_stream_v1_listener stream_listener = {
+    handle_stream_complete,
+    handle_stream_failure
+};
+
+static void
+start_streams(WaylandContextStruct* wlcontext)
+{
+    struct debug_stream *stream;
+
+    wl_list_for_each(stream, &wlcontext->stream_list, link) {
+        stream->obj = weston_debug_v1_subscribe(wlcontext->debug_iface,
+                            stream->name,
+                            wlcontext->debug_fd);
+        weston_debug_stream_v1_add_listener(stream->obj,
+                            &stream_listener, stream);
+    }
+}
+
+static void
+get_debug_streams(WaylandContextStruct* wlcontext)
+{
+    char *stream_names;
+    char *stream;
+    const char separator[2] = " ";
+
+    stream_names = getenv("IVI_CLIENT_DEBUG_STREAM_NAMES");
+
+    /* get the first stream */
+    stream = strtok(stream_names, separator);
+
+    /* walk through other streams */
+    while( stream != NULL ) {
+        stream_alloc(wlcontext, stream);
+        stream = strtok(NULL, separator);
+    }
 }
 
 static void
@@ -261,6 +380,17 @@ registry_handle_global(void *data, struct wl_registry *registry, uint32_t name,
                 wl_registry_bind(registry, name, &wl_seat_interface, 1);
         wl_seat_add_listener(wlcontext->wl_seat, &seat_Listener, data);
     }
+    if (!strcmp(interface, weston_debug_v1_interface.name)) {
+        uint32_t myver;
+
+        if (wlcontext->debug_iface || wl_list_empty(&wlcontext->stream_list))
+            return;
+
+        myver = MIN(1, version);
+        wlcontext->debug_iface =
+                wl_registry_bind(registry, name,
+                    &weston_debug_v1_interface, myver);
+    }
 }
 
 static void
@@ -310,6 +440,9 @@ void destroy_wayland_context(WaylandContextStruct* wlcontext)
 
     if(wlcontext->wl_display)
         wl_display_disconnect(wlcontext->wl_display);
+
+    if(wlcontext->debug_iface)
+        weston_debug_v1_destroy(wlcontext->debug_iface);
 }
 
 int
@@ -462,6 +595,12 @@ int main (int argc, const char * argv[])
     /*init wayland context*/
     wlcontext = (WaylandContextStruct*)calloc(1, sizeof(WaylandContextStruct));
     wlcontext->bkgnd_settings = bkgnd_settings;
+
+    /*init debug stream list*/
+    wl_list_init(&wlcontext->stream_list);
+    get_debug_streams(wlcontext);
+    wlcontext->debug_fd = STDOUT_FILENO;
+
     if (init_wayland_context(wlcontext)) {
         fprintf(stderr, "init_wayland_context failed\n");
         return -1;
@@ -474,6 +613,11 @@ int main (int argc, const char * argv[])
 
     wl_display_roundtrip(wlcontext->wl_display);
 
+    if (!wl_list_empty(&wlcontext->stream_list) &&
+            wlcontext->debug_iface) {
+        start_streams(wlcontext);
+    }
+
     /*draw the bkgnd display*/
     draw_bkgnd_surface(wlcontext);
 
@@ -481,6 +625,7 @@ int main (int argc, const char * argv[])
         ret = wl_display_dispatch(wlcontext->wl_display);
 
 Error:
+    destroy_streams(wlcontext);
     destroy_bkgnd_surface(wlcontext);
     destroy_wayland_context(wlcontext);
 

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -1992,7 +1992,7 @@ get_config(struct weston_compositor *compositor, struct ivishell *shell)
 
 	weston_config_section_get_int(section,
                        "bkgnd-surface-id",
-                       &shell->bkgnd_surface_id, -1);
+                       &shell->bkgnd_surface_id, 0);
 
 	weston_config_section_get_string(section,
 	                   "debug-scopes",
@@ -2176,8 +2176,11 @@ launch_client_process(void *data)
             (struct ivishell *)data;
     char option[128] = {0};
 
-    sprintf(option, "%d", shell->bkgnd_surface_id);
-    setenv(IVI_CLIENT_SURFACE_ID_ENV_NAME, option, 0x1);
+    if (0 != shell->bkgnd_surface_id) {
+        sprintf(option, "%d", shell->bkgnd_surface_id);
+        setenv(IVI_CLIENT_SURFACE_ID_ENV_NAME, option, 0x1);
+    }
+
     if (shell->debug_scopes) {
         setenv(IVI_CLIENT_DEBUG_SCOPES_ENV_NAME, shell->debug_scopes, 0x1);
         free(shell->debug_scopes);
@@ -2238,7 +2241,7 @@ controller_module_init(struct weston_compositor *compositor,
         return -1;
     }
 
-    if (shell->bkgnd_surface_id && shell->ivi_client_name) {
+    if (shell->ivi_client_name) {
         loop = wl_display_get_event_loop(compositor->wl_display);
         wl_event_loop_add_idle(loop, launch_client_process, shell);
     }

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -45,6 +45,7 @@
 #endif
 
 #define IVI_CLIENT_SURFACE_ID_ENV_NAME "IVI_CLIENT_SURFACE_ID"
+#define IVI_CLIENT_DEBUG_SCOPES_ENV_NAME "IVI_CLIENT_DEBUG_STREAM_NAMES"
 
 struct ivilayer;
 struct iviscreen;
@@ -1993,6 +1994,10 @@ get_config(struct weston_compositor *compositor, struct ivishell *shell)
                        "bkgnd-surface-id",
                        &shell->bkgnd_surface_id, -1);
 
+	weston_config_section_get_string(section,
+	                   "debug-scopes",
+	                   &shell->debug_scopes, NULL);
+
 	weston_config_section_get_color(section,
                        "bkgnd-color",
                        &shell->bkgnd_color, 0xFF000000);
@@ -2173,11 +2178,13 @@ launch_client_process(void *data)
 
     sprintf(option, "%d", shell->bkgnd_surface_id);
     setenv(IVI_CLIENT_SURFACE_ID_ENV_NAME, option, 0x1);
+    setenv(IVI_CLIENT_DEBUG_SCOPES_ENV_NAME, shell->debug_scopes, 0x1);
 
     shell->client = weston_client_start(shell->compositor,
                                         shell->ivi_client_name);
 
     free(shell->ivi_client_name);
+    free(shell->debug_scopes);
 }
 
 WL_EXPORT int

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -45,6 +45,7 @@
 #endif
 
 #define IVI_CLIENT_SURFACE_ID_ENV_NAME "IVI_CLIENT_SURFACE_ID"
+#define IVI_CLIENT_CURSOR_ENABLE_ENV_NAME "IVI_CLIENT_CURSOR_ENABLE"
 #define IVI_CLIENT_DEBUG_SCOPES_ENV_NAME "IVI_CLIENT_DEBUG_STREAM_NAMES"
 
 struct ivilayer;
@@ -1994,6 +1995,23 @@ get_config(struct weston_compositor *compositor, struct ivishell *shell)
                        "bkgnd-surface-id",
                        &shell->bkgnd_surface_id, 0);
 
+	/* cursor is enabled by default,
+	 * if the user doesn't want the cursor
+	 * then cursor-enable option can be set
+	 * as false in weston.ini */
+	weston_config_section_get_bool(section,
+                       "cursor-enable",
+                       &shell->cursor_enable, 0);
+
+	/* if cursor is enabled,
+	 * background surface has to be created
+	 * even it is not configured by the user
+	 * otherwise the cursor can't be set */
+	if (shell->cursor_enable &&
+	    (0 == shell->bkgnd_surface_id)) {
+	    shell->bkgnd_surface_id = 1000000;
+	}
+
 	weston_config_section_get_string(section,
 	                   "debug-scopes",
 	                   &shell->debug_scopes, NULL);
@@ -2179,6 +2197,11 @@ launch_client_process(void *data)
     if (0 != shell->bkgnd_surface_id) {
         sprintf(option, "%d", shell->bkgnd_surface_id);
         setenv(IVI_CLIENT_SURFACE_ID_ENV_NAME, option, 0x1);
+    }
+
+    if (0 != shell->cursor_enable) {
+        sprintf(option, "%d", shell->cursor_enable);
+        setenv(IVI_CLIENT_CURSOR_ENABLE_ENV_NAME, option, 0x1);
     }
 
     if (shell->debug_scopes) {

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -2178,13 +2178,15 @@ launch_client_process(void *data)
 
     sprintf(option, "%d", shell->bkgnd_surface_id);
     setenv(IVI_CLIENT_SURFACE_ID_ENV_NAME, option, 0x1);
-    setenv(IVI_CLIENT_DEBUG_SCOPES_ENV_NAME, shell->debug_scopes, 0x1);
+    if (shell->debug_scopes) {
+        setenv(IVI_CLIENT_DEBUG_SCOPES_ENV_NAME, shell->debug_scopes, 0x1);
+        free(shell->debug_scopes);
+    }
 
     shell->client = weston_client_start(shell->compositor,
                                         shell->ivi_client_name);
 
     free(shell->ivi_client_name);
-    free(shell->debug_scopes);
 }
 
 WL_EXPORT int

--- a/weston-ivi-shell/src/ivi-controller.h
+++ b/weston-ivi-shell/src/ivi-controller.h
@@ -71,6 +71,7 @@ struct ivishell {
     uint32_t screen_id_offset;
 
     int32_t bkgnd_surface_id;
+    int32_t cursor_enable;
     uint32_t bkgnd_color;
     struct ivisurface *bkgnd_surface;
     struct weston_layer bkgnd_layer;

--- a/weston-ivi-shell/src/ivi-controller.h
+++ b/weston-ivi-shell/src/ivi-controller.h
@@ -79,6 +79,7 @@ struct ivishell {
 
     struct wl_client *client;
     char *ivi_client_name;
+    char *debug_scopes;
 };
 
 #endif /* WESTON_IVI_SHELL_SRC_IVI_CONTROLLER_H_ */


### PR DESCRIPTION
Hi,

Please review and merge these patches related to weston-debug feature addition in weston-helper client.
Since we keep the libweston-2-protocols locally, it is added here as PkgConfig based. Along with these changes, bkgnd surface creation and and default mouse cursor rendering is also made as to be enabled/disabled  through the option from weston.ini

Best Regards,
Maniraj D