### PR TITLE
Fix set surface & layer destination rectangle of ivi-controller

### DIFF
--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -744,10 +744,6 @@ controller_set_layer_destination_rectangle(struct wl_client *client,
 
     prop = lyt->get_properties_of_layer(layout_layer);
 
-    if (x < 0)
-        x = prop->dest_x;
-    if (y < 0)
-        y = prop->dest_y;
     if (width < 0)
         width = prop->dest_width;
     if (height < 0)

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -363,10 +363,6 @@ controller_set_surface_destination_rectangle(struct wl_client *client,
                                      IVI_LAYOUT_TRANSITION_NONE,
                                      300); // ms
 
-    if (x < 0)
-        x = prop->dest_x;
-    if (y < 0)
-        y = prop->dest_y;
     if (width < 0)
         width = prop->dest_width;
     if (height < 0)


### PR DESCRIPTION
Refer to weston compositor, negative detection for x & y params only needed for set source rectangle