### PR TITLE
ivi-input: remove seat acceptance from surface when seat is destroyed

### DIFF
--- a/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
+++ b/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
@@ -157,11 +157,9 @@ add_accepted_seat(struct ivisurface *surface, const char *seat)
 }
 
 static int
-remove_accepted_seat(struct ivisurface *surface, const char *seat)
+remove_if_seat_accepted(struct ivisurface *surface, const char *seat)
 {
     int ret = 0;
-    const struct ivi_layout_interface *interface =
-            surface->shell->interface;
 
     struct seat_focus *st_focus = get_accepted_seat(surface, seat);
 
@@ -171,10 +169,6 @@ remove_accepted_seat(struct ivisurface *surface, const char *seat)
         free(st_focus->seat_name);
         free(st_focus);
 
-    } else {
-        weston_log("%s: Warning: seat '%s' not found for surface %u\n",
-                  __FUNCTION__, seat,
-                  interface->get_id_of_surface(surface->layout_surface));
     }
     return ret;
 }
@@ -933,7 +927,7 @@ handle_seat_destroy(struct wl_listener *listener, void *data)
     /* Remove seat acceptance from surfaces which have input acceptance from
      * this seat */
     wl_list_for_each(surf, &input_ctx->ivishell->list_surface, link) {
-         remove_accepted_seat(surf, ctx->name_seat);
+         remove_if_seat_accepted(surf, ctx->name_seat);
     }
 
     wl_list_for_each(controller, &ctx->input_ctx->controller_list, link) {
@@ -1177,7 +1171,7 @@ setup_input_acceptance(struct input_context *ctx,
                     }
                 }
 
-                found_seat = remove_accepted_seat(ivisurface, seat);
+                found_seat = remove_if_seat_accepted(ivisurface, seat);
             }
         }
     }

--- a/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
+++ b/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
@@ -920,6 +920,8 @@ handle_seat_destroy(struct wl_listener *listener, void *data)
     struct seat_ctx *ctx = wl_container_of(listener, ctx, destroy_listener);
     struct weston_seat *seat = data;
     struct input_controller *controller;
+    struct input_context* input_ctx = ctx->input_ctx;
+    struct ivisurface *surf;
 
     if (ctx->keyboard_grab.keyboard)
         keyboard_grab_cancel(&ctx->keyboard_grab);
@@ -927,6 +929,12 @@ handle_seat_destroy(struct wl_listener *listener, void *data)
         pointer_grab_cancel(&ctx->pointer_grab);
     if (ctx->touch_grab.touch)
         touch_grab_cancel(&ctx->touch_grab);
+
+    /* Remove seat acceptance from surfaces which have input acceptance from
+     * this seat */
+    wl_list_for_each(surf, &input_ctx->ivishell->list_surface, link) {
+         remove_accepted_seat(surf, ctx->name_seat);
+    }
 
     wl_list_for_each(controller, &ctx->input_ctx->controller_list, link) {
         ivi_input_send_seat_destroyed(controller->resource,


### PR DESCRIPTION
When a seat is destroyed remove the seat acceptance entry from surfaces which accept input events from this seat.

 It is necessary that HMI controller monitors seat creation and  destruction events, for setting seat acceptance and input focus.
