### PR TITLE
wayland-ivi-extension: Correct the dependency order

### DIFF
--- a/ivi-layermanagement-api/ilmCommon/CMakeLists.txt
+++ b/ivi-layermanagement-api/ilmCommon/CMakeLists.txt
@@ -25,6 +25,7 @@ project(ilmCommon)
 find_package(Threads)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
+GET_TARGET_PROPERTY(ILM_CONTROL_INCLUDE_DIRS ilmControl INCLUDE_DIRECTORIES)
 
 include_directories(
     include
@@ -42,10 +43,12 @@ add_library(${PROJECT_NAME} SHARED
 
 target_link_libraries(${PROJECT_NAME}
     ${WAYLAND_CLIENT_LIBRARIES}
+    ilmControl
 )
 
 add_dependencies(${PROJECT_NAME}
     ${WAYLAND_CLIENT_LIBRARIES}
+    ilmControl
 )
 
 install (

--- a/ivi-layermanagement-api/ilmCommon/ilmCommon.pc.in
+++ b/ivi-layermanagement-api/ilmCommon/ilmCommon.pc.in
@@ -6,6 +6,7 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/ilm
 Name: ilmCommon
 Description: Library for common part of ilm api
 Version: @ILM_API_VERSION@
+Requires: ilmControl
 Requires.private: wayland-client
 Libs: -L${libdir} -lilmCommon
 Cflags: -I${includedir}

--- a/ivi-layermanagement-api/ilmControl/CMakeLists.txt
+++ b/ivi-layermanagement-api/ilmControl/CMakeLists.txt
@@ -83,13 +83,11 @@ add_library(${PROJECT_NAME} SHARED
 )
 
 add_dependencies(${PROJECT_NAME}
-    ilmCommon
     ${WAYLAND_CLIENT_LIBRARIES}
 )
 
 set(LIBS
     ${LIBS}
-    ilmCommon
     rt
     dl
     ${CMAKE_THREAD_LIBS_INIT}

--- a/ivi-layermanagement-api/ilmControl/ilmControl.pc.in
+++ b/ivi-layermanagement-api/ilmControl/ilmControl.pc.in
@@ -6,7 +6,6 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/ilm
 Name: ilmControl
 Description: Library for control part of ilm api
 Version: @ILM_API_VERSION@
-Requires: ilmCommon
 Requires.private: wayland-client
 Libs: -L${libdir} -lilmControl
 Cflags: -I${includedir}

--- a/ivi-layermanagement-examples/LayerManagerControl/CMakeLists.txt
+++ b/ivi-layermanagement-examples/LayerManagerControl/CMakeLists.txt
@@ -32,7 +32,7 @@ link_directories(
 )
 
 SET(LIBS
-    ilmControl
+    ilmCommon
     ilmInput
 )
 

--- a/ivi-layermanagement-examples/layer-add-surfaces/CMakeLists.txt
+++ b/ivi-layermanagement-examples/layer-add-surfaces/CMakeLists.txt
@@ -32,7 +32,7 @@ link_directories(
 )
 
 SET(LIBS
-    ilmControl
+    ilmCommon
 )
 
 SET(SRC_FILES


### PR DESCRIPTION
Currently, ilmControl depends on ilmCommon. However, it is
ilmCommon that should depend on ilmControl.

Functions ilmControl_init and ilmControl_destroy are defined in
ilmControl, but are getting called from ilmCommon. Hence, ilmCommon
won't work without having ilmControl on the system at runtime. If
not found, there will be a runtime error which could be avoided
by linking these libraries correctly at build time.

Moreover, there is only a build time dependency of include headers
of ilmCommon on ilmControl. So at runtime, even if ilmCommon is not
present on the system, ilmControl can function independently.

This change corrects the dependency order of ilmCommon and
ilmControl.

Signed-off-by: Ashutosh Agarwal <asagarwal@nvidia.com>
Reviewed-by: Miguel Vico Moya <mvicomoya@nvidia.com>