### PR TITLE
FIX: variable keymap_fd is changed to ref_count in weston 5.0 in libw…

### DIFF
--- a/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
+++ b/ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c
@@ -255,7 +255,7 @@ input_ctrl_kbd_snd_event_resource(struct seat_ctx *ctx_seat,
 
         wl_keyboard_send_keymap(resource,
                        WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1,
-                       keyboard->xkb_info->keymap_fd,
+                       keyboard->xkb_info->ref_count,
                        keyboard->xkb_info->keymap_size);
 
         wl_keyboard_send_modifiers(resource,


### PR DESCRIPTION
…eston/compositor.h

changed the variable name to ref_count from keymap_fd in file "ivi-input-modules/ivi-input-controller/src/ivi-input-controller.c"
The name of the member variable is changed in weston 5.0 file "libweston/compositor.h" in "struct weston_xkb_info"