### PR TITLE
 Weston debug support

### DIFF
--- a/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
+++ b/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
@@ -25,6 +25,9 @@ pkg_check_modules(WAYLAND_CURSOR wayland-cursor REQUIRED)
 pkg_check_modules(LIBWESTON_PROTOCOLS libweston-2-protocols QUIET)
 
 if(${LIBWESTON_PROTOCOLS_FOUND})
+    #check for DLT
+    pkg_check_modules(DLT automotive-dlt REQUIRED)
+
     #import the pkgdatadir from libweston-protocols pkgconfig file
     execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=pkgdatadir libweston-2-protocols
                     OUTPUT_VARIABLE WestonProtocols_PKGDATADIR)
@@ -80,16 +83,19 @@ include_directories(
     ${WAYLAND_CLIENT_INCLUDE_DIR}
     ${WAYLAND_CURSOR_INCLUDE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
+    ${DLT_INCLUDE_DIR}
 )
 
 link_directories(
     ${WAYLAND_CLIENT_LIBRARY_DIRS}
     ${WAYLAND_CURSOR_LIBRARY_DIRS}
+    ${DLT_LIBRARY_DIRS}
 )
 
 SET(LIBS
     ${WAYLAND_CLIENT_LIBRARIES}
     ${WAYLAND_CURSOR_LIBRARIES}
+    ${DLT_LIBRARIES}
 )
 
 SET(SRC_FILES
@@ -109,6 +115,8 @@ endif(${LIBWESTON_PROTOCOLS_FOUND})
 add_executable(${PROJECT_NAME} ${SRC_FILES} ${WESTON_DEBUG_SRC_FILES})
 
 add_dependencies(${PROJECT_NAME} ${LIBS})
+
+add_definitions(${DLT_CFLAGS})
 
 target_link_libraries(${PROJECT_NAME} ${LIBS})
 

--- a/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
+++ b/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
@@ -22,14 +22,14 @@ project (simple-weston-client)
 find_package(PkgConfig)
 pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
 pkg_check_modules(WAYLAND_CURSOR wayland-cursor REQUIRED)
-pkg_check_modules(LIBWESTON_PROTOCOLS libweston-2-protocols QUIET)
+pkg_check_modules(LIBWESTON_PROTOCOLS libweston-6-protocols QUIET)
 
 if(${LIBWESTON_PROTOCOLS_FOUND})
     #check for DLT
     pkg_check_modules(DLT automotive-dlt REQUIRED)
 
     #import the pkgdatadir from libweston-protocols pkgconfig file
-    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=pkgdatadir libweston-2-protocols
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=pkgdatadir libweston-6-protocols
                     OUTPUT_VARIABLE WestonProtocols_PKGDATADIR)
     string(REGEX REPLACE "[\r\n]" "" WestonProtocols_PKGDATADIR "${WestonProtocols_PKGDATADIR}")
     SET(LIBWESTON_PROTOCOLS_PKGDATADIR ${WestonProtocols_PKGDATADIR})

--- a/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
+++ b/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
@@ -118,6 +118,10 @@ add_dependencies(${PROJECT_NAME} ${LIBS})
 
 add_definitions(${DLT_CFLAGS})
 
+if(${LIBWESTON_PROTOCOLS_FOUND})
+    add_definitions(-DLIBWESTON_DEBUG_PROTOCOL)
+endif(${LIBWESTON_PROTOCOLS_FOUND})
+
 target_link_libraries(${PROJECT_NAME} ${LIBS})
 
 install (TARGETS ${PROJECT_NAME} DESTINATION bin)

--- a/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
+++ b/ivi-layermanagement-examples/simple-weston-client/CMakeLists.txt
@@ -22,6 +22,15 @@ project (simple-weston-client)
 find_package(PkgConfig)
 pkg_check_modules(WAYLAND_CLIENT wayland-client REQUIRED)
 pkg_check_modules(WAYLAND_CURSOR wayland-cursor REQUIRED)
+pkg_check_modules(LIBWESTON_PROTOCOLS libweston-2-protocols QUIET)
+
+if(${LIBWESTON_PROTOCOLS_FOUND})
+    #import the pkgdatadir from libweston-protocols pkgconfig file
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=pkgdatadir libweston-2-protocols
+                    OUTPUT_VARIABLE WestonProtocols_PKGDATADIR)
+    string(REGEX REPLACE "[\r\n]" "" WestonProtocols_PKGDATADIR "${WestonProtocols_PKGDATADIR}")
+    SET(LIBWESTON_PROTOCOLS_PKGDATADIR ${WestonProtocols_PKGDATADIR})
+endif(${LIBWESTON_PROTOCOLS_FOUND})
 
 find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
 
@@ -40,6 +49,32 @@ add_custom_command(
             > ${CMAKE_CURRENT_BINARY_DIR}/ivi-application-protocol.c
     DEPENDS ${CMAKE_SOURCE_DIR}/protocol/ivi-application.xml
 )
+
+if(${LIBWESTON_PROTOCOLS_FOUND})
+    add_custom_command(
+        OUTPUT  weston-debug-client-protocol.h
+        COMMAND ${WAYLAND_SCANNER_EXECUTABLE} client-header
+                < ${LIBWESTON_PROTOCOLS_PKGDATADIR}/weston-debug.xml
+                > ${CMAKE_CURRENT_BINARY_DIR}/weston-debug-client-protocol.h
+        DEPENDS ${LIBWESTON_PROTOCOLS_PKGDATADIR}/weston-debug.xml
+    )
+
+    add_custom_command(
+        OUTPUT  weston-debug-server-protocol.h
+        COMMAND ${WAYLAND_SCANNER_EXECUTABLE} server-header
+                < ${LIBWESTON_PROTOCOLS_PKGDATADIR}/weston-debug.xml
+                > ${CMAKE_CURRENT_BINARY_DIR}/weston-debug-server-protocol.h
+        DEPENDS ${LIBWESTON_PROTOCOLS_PKGDATADIR}/weston-debug.xml
+    )
+
+    add_custom_command(
+        OUTPUT  weston-debug-protocol.c
+        COMMAND ${WAYLAND_SCANNER_EXECUTABLE} code
+                < ${LIBWESTON_PROTOCOLS_PKGDATADIR}/weston-debug.xml
+                > ${CMAKE_CURRENT_BINARY_DIR}/weston-debug-protocol.c
+        DEPENDS ${LIBWESTON_PROTOCOLS_PKGDATADIR}/weston-debug.xml
+    )
+endif(${LIBWESTON_PROTOCOLS_FOUND})
 
 include_directories(
     ${WAYLAND_CLIENT_INCLUDE_DIR}
@@ -63,7 +98,15 @@ SET(SRC_FILES
     ivi-application-client-protocol.h
 )
 
-add_executable(${PROJECT_NAME} ${SRC_FILES})
+if(${LIBWESTON_PROTOCOLS_FOUND})
+    SET(WESTON_DEBUG_SRC_FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/weston-debug-protocol.c
+        ${CMAKE_CURRENT_BINARY_DIR}/weston-debug-client-protocol.h
+        ${CMAKE_CURRENT_BINARY_DIR}/weston-debug-server-protocol.h
+)
+endif(${LIBWESTON_PROTOCOLS_FOUND})
+
+add_executable(${PROJECT_NAME} ${SRC_FILES} ${WESTON_DEBUG_SRC_FILES})
 
 add_dependencies(${PROJECT_NAME} ${LIBS})
 

--- a/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
+++ b/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
@@ -28,6 +28,12 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <assert.h>
+#include <pthread.h>
+#include <signal.h>
+#include <poll.h>
+
+#include "dlt_common.h"
+#include "dlt_user.h"
 
 #include <wayland-cursor.h>
 #include <ivi-application-client-protocol.h>
@@ -37,6 +43,8 @@
 #ifndef MIN
 #define MIN(x,y) (((x) < (y)) ? (x) : (y))
 #endif
+
+static int running = 1;
 
 typedef struct _BkGndSettings
 {
@@ -66,6 +74,9 @@ typedef struct _WaylandContext {
     uint32_t                formats;
     struct wl_list          stream_list;
     int                     debug_fd;
+    char                    thread_running;
+    pthread_t               dlt_ctx_thread;
+    int                     pipefd[2];
 }WaylandContextStruct;
 
 struct debug_stream {
@@ -80,6 +91,14 @@ static const char *left_ptrs[] = {
     "top_left_arrow",
     "left-arrow"
 };
+
+#define WESTON_DLT_APP_DESC "messages from weston debug protocol"
+#define WESTON_DLT_CONTEXT_DESC "weston debug context"
+
+#define WESTON_DLT_APP "WESN"
+#define WESTON_DLT_CONTEXT "WESC"
+
+#define MAXSTRLEN 1024
 
 static BkGndSettingsStruct*
 get_bkgnd_settings(void)
@@ -624,11 +643,128 @@ void destroy_bkgnd_surface(WaylandContextStruct* wlcontext)
         wl_surface_destroy(wlcontext->wlBkgndSurface);
 }
 
+static void *
+weston_dlt_thread_function(void *data)
+{
+    WaylandContextStruct* wlcontext;
+    char apid[DLT_ID_SIZE];
+    char ctid[DLT_ID_SIZE];
+    char *temp;
+    DLT_DECLARE_CONTEXT(weston_dlt_context)
+
+    wlcontext = (WaylandContextStruct*)data;
+
+    /*init dlt*/
+    dlt_set_id(apid, WESTON_DLT_APP);
+    dlt_set_id(ctid, WESTON_DLT_CONTEXT);
+
+    DLT_REGISTER_APP(apid, WESTON_DLT_APP_DESC);
+    DLT_REGISTER_CONTEXT(weston_dlt_context, ctid, WESTON_DLT_CONTEXT_DESC);
+
+    /*make the stdin as read end of the pipe*/
+    dup2(wlcontext->pipefd[0], STDIN_FILENO);
+
+    while (running && wlcontext->thread_running)
+    {
+        char str[MAXSTRLEN] = {0};
+        int i = -1;
+
+        /* read from std-in(read end of pipe) till newline char*/
+        do {
+            i++;
+            read(wlcontext->pipefd[0], &str[i], 1);
+        } while (str[i] != '\n');
+
+        if (strcmp(str,"")!=0)
+        {
+            DLT_LOG(weston_dlt_context, DLT_LOG_INFO, DLT_STRING(str));
+        }
+    }
+
+    DLT_UNREGISTER_CONTEXT(weston_dlt_context);
+    DLT_UNREGISTER_APP();
+    pthread_exit(NULL);
+}
+
+static void
+signal_int(int signum)
+{
+    running = 0;
+}
+
+static int
+display_poll(struct wl_display *display, short int events)
+{
+    int ret;
+    struct pollfd pfd[1];
+
+    pfd[0].fd = wl_display_get_fd(display);
+    pfd[0].events = events;
+    do {
+        ret = poll(pfd, 1, -1);
+    } while (ret == -1 && errno == EINTR && running);
+
+    if(0 == running)
+        ret = -1;
+
+    return ret;
+}
+
+/* implemented local API for dispatch the default queue
+ * to handle the Ctrl+C signal properly, with the wl_display_dispatch
+ * the poll is continuing because the generated errno is EINTR,
+ * so added running flag also to decide whether to continue polling or not */
+static int
+display_dispatch(struct wl_display *display)
+{
+    int ret;
+
+    if (wl_display_prepare_read(display) == -1)
+        return wl_display_dispatch_pending(display);
+
+    while (1) {
+        ret = wl_display_flush(display);
+
+        if (ret != -1 || errno != EAGAIN)
+            break;
+
+        if (display_poll(display, POLLOUT) == -1) {
+            wl_display_cancel_read(display);
+            return -1;
+        }
+    }
+
+    /* Don't stop if flushing hits an EPIPE; continue so we can read any
+     * protocol error that may have triggered it. */
+    if (ret < 0 && errno != EPIPE) {
+        wl_display_cancel_read(display);
+        return -1;
+    }
+
+    if (display_poll(display, POLLIN) == -1) {
+        wl_display_cancel_read(display);
+        return -1;
+    }
+
+    if (wl_display_read_events(display) == -1)
+        return -1;
+
+    return wl_display_dispatch_pending(display);
+}
+
 int main (int argc, const char * argv[])
 {
     WaylandContextStruct* wlcontext;
     BkGndSettingsStruct* bkgnd_settings;
+    struct sigaction sigint;
+    int offset = 0;
     int ret = 0;
+
+    sigint.sa_handler = signal_int;
+    sigemptyset(&sigint.sa_mask);
+    sigaction(SIGINT, &sigint, NULL);
+    sigaction(SIGTERM, &sigint, NULL);
+    sigaction(SIGSEGV, &sigint, NULL);
 
     /*get bkgnd settings and create shm-surface*/
     bkgnd_settings = get_bkgnd_settings();
@@ -656,20 +792,42 @@ int main (int argc, const char * argv[])
 
     if (!wl_list_empty(&wlcontext->stream_list) &&
             wlcontext->debug_iface) {
+        /* create the pipe b/w stdout and stdin
+         * stdout - write end
+         * stdin - read end
+         * weston will write to stdout and the
+         * dlt_ctx_thread will read from stdin */
+        pipe(wlcontext->pipefd);
+        dup2(wlcontext->pipefd[1], STDOUT_FILENO);
+
+        wlcontext->thread_running = 1;
+        pthread_create(&wlcontext->dlt_ctx_thread, NULL,
+                weston_dlt_thread_function, wlcontext);
         start_streams(wlcontext);
     }
 
     /*draw the bkgnd display*/
     draw_bkgnd_surface(wlcontext);
 
-    while (ret != -1)
-        ret = wl_display_dispatch(wlcontext->wl_display);
+    while (running && (ret != -1))
+        ret = display_dispatch(wlcontext->wl_display);
 
 Error:
     destroy_streams(wlcontext);
+    wl_display_roundtrip(wlcontext->wl_display);
+
     destroy_bkgnd_surface(wlcontext);
 ErrorContext:
     destroy_wayland_context(wlcontext);
+
+    if(wlcontext->thread_running)
+    {
+        close(wlcontext->pipefd[1]);
+        close(STDOUT_FILENO);
+        wlcontext->thread_running = 0;
+        pthread_join(wlcontext->dlt_ctx_thread, NULL);
+        close(wlcontext->pipefd[0]);
+    }
 
     free(bkgnd_settings);
     free(wlcontext);

--- a/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
+++ b/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
@@ -32,13 +32,22 @@
 #include <signal.h>
 #include <poll.h>
 
-#include "dlt_common.h"
-#include "dlt_user.h"
-
 #include <wayland-cursor.h>
 #include <ivi-application-client-protocol.h>
 
+#ifdef LIBWESTON_DEBUG_PROTOCOL
+#include "dlt_common.h"
+#include "dlt_user.h"
 #include "weston-debug-client-protocol.h"
+
+#define WESTON_DLT_APP_DESC "messages from weston debug protocol"
+#define WESTON_DLT_CONTEXT_DESC "weston debug context"
+
+#define WESTON_DLT_APP "WESN"
+#define WESTON_DLT_CONTEXT "WESC"
+
+#define MAXSTRLEN 1024
+#endif
 
 #ifndef MIN
 #define MIN(x,y) (((x) < (y)) ? (x) : (y))
@@ -60,7 +69,6 @@ typedef struct _WaylandContext {
     struct wl_compositor    *wl_compositor;
     struct wl_shm           *wl_shm;
     struct wl_seat          *wl_seat;
-    struct weston_debug_v1  *debug_iface;
     struct wl_pointer       *wl_pointer;
     struct wl_surface       *wl_pointer_surface;
     struct ivi_application  *ivi_application;
@@ -72,11 +80,14 @@ typedef struct _WaylandContext {
     struct wl_cursor        *cursor;
     void                    *bkgnddata;
     uint32_t                formats;
+#ifdef LIBWESTON_DEBUG_PROTOCOL
+    struct weston_debug_v1  *debug_iface;
     struct wl_list          stream_list;
     int                     debug_fd;
     char                    thread_running;
     pthread_t               dlt_ctx_thread;
     int                     pipefd[2];
+#endif
 }WaylandContextStruct;
 
 struct debug_stream {
@@ -91,14 +102,6 @@ static const char *left_ptrs[] = {
     "top_left_arrow",
     "left-arrow"
 };
-
-#define WESTON_DLT_APP_DESC "messages from weston debug protocol"
-#define WESTON_DLT_CONTEXT_DESC "weston debug context"
-
-#define WESTON_DLT_APP "WESN"
-#define WESTON_DLT_CONTEXT "WESC"
-
-#define MAXSTRLEN 1024
 
 static BkGndSettingsStruct*
 get_bkgnd_settings(void)
@@ -123,6 +126,7 @@ get_bkgnd_settings(void)
     return bkgnd_settings;
 }
 
+#ifdef LIBWESTON_DEBUG_PROTOCOL
 static struct debug_stream *
 stream_alloc(WaylandContextStruct* wlcontext, const char *name)
 {
@@ -228,6 +232,7 @@ get_debug_streams(WaylandContextStruct* wlcontext)
         stream = strtok(NULL, separator);
     }
 }
+#endif
 
 static void
 shm_format(void *data, struct wl_shm *wl_shm, uint32_t format)
@@ -440,7 +445,8 @@ registry_handle_global(void *data, struct wl_registry *registry, uint32_t name,
                 wl_registry_bind(registry, name, &wl_seat_interface, 1);
         wl_seat_add_listener(wlcontext->wl_seat, &seat_Listener, data);
     }
-    if (!strcmp(interface, weston_debug_v1_interface.name)) {
+#ifdef LIBWESTON_DEBUG_PROTOCOL
+    else if (!strcmp(interface, weston_debug_v1_interface.name)) {
         uint32_t myver;
 
         if (wlcontext->debug_iface || wl_list_empty(&wlcontext->stream_list))
@@ -451,6 +457,7 @@ registry_handle_global(void *data, struct wl_registry *registry, uint32_t name,
                 wl_registry_bind(registry, name,
                     &weston_debug_v1_interface, myver);
     }
+#endif
 }
 
 static void
@@ -490,6 +497,14 @@ int init_wayland_context(WaylandContextStruct* wlcontext)
         return -1;
     }
 
+#ifdef LIBWESTON_DEBUG_PROTOCOL
+    if (!wl_list_empty(&wlcontext->stream_list) &&
+        (wlcontext->debug_iface == NULL)) {
+        fprintf(stderr, "WARNING: weston_debug protocol is not available,"
+                " missed enabling --debug option to weston ?\n");
+    }
+#endif
+
     return 0;
 }
 
@@ -501,8 +516,10 @@ void destroy_wayland_context(WaylandContextStruct* wlcontext)
     if(wlcontext->wl_display)
         wl_display_disconnect(wlcontext->wl_display);
 
+#ifdef LIBWESTON_DEBUG_PROTOCOL
     if(wlcontext->debug_iface)
         weston_debug_v1_destroy(wlcontext->debug_iface);
+#endif
 }
 
 int
@@ -643,6 +660,7 @@ void destroy_bkgnd_surface(WaylandContextStruct* wlcontext)
         wl_surface_destroy(wlcontext->wlBkgndSurface);
 }
 
+#ifdef LIBWESTON_DEBUG_PROTOCOL
 static void *
 weston_dlt_thread_function(void *data)
 {
@@ -685,6 +703,7 @@ weston_dlt_thread_function(void *data)
     DLT_UNREGISTER_APP();
     pthread_exit(NULL);
 }
+#endif
 
 static void
 signal_int(int signum)
@@ -773,10 +792,14 @@ int main (int argc, const char * argv[])
     wlcontext = (WaylandContextStruct*)calloc(1, sizeof(WaylandContextStruct));
     wlcontext->bkgnd_settings = bkgnd_settings;
 
+#ifdef LIBWESTON_DEBUG_PROTOCOL
     /*init debug stream list*/
     wl_list_init(&wlcontext->stream_list);
     get_debug_streams(wlcontext);
     wlcontext->debug_fd = STDOUT_FILENO;
+#else
+    fprintf(stderr, "WARNING: weston_debug protocol is not available\n");
+#endif
 
     if (init_wayland_context(wlcontext)) {
         fprintf(stderr, "init_wayland_context failed\n");
@@ -790,6 +813,7 @@ int main (int argc, const char * argv[])
 
     wl_display_roundtrip(wlcontext->wl_display);
 
+#ifdef LIBWESTON_DEBUG_PROTOCOL
     if (!wl_list_empty(&wlcontext->stream_list) &&
             wlcontext->debug_iface) {
         /* create the pipe b/w stdout and stdin
@@ -805,6 +829,7 @@ int main (int argc, const char * argv[])
                 weston_dlt_thread_function, wlcontext);
         start_streams(wlcontext);
     }
+#endif
 
     /*draw the bkgnd display*/
     draw_bkgnd_surface(wlcontext);
@@ -813,12 +838,9 @@ int main (int argc, const char * argv[])
         ret = display_dispatch(wlcontext->wl_display);
 
 Error:
+#ifdef LIBWESTON_DEBUG_PROTOCOL
     destroy_streams(wlcontext);
     wl_display_roundtrip(wlcontext->wl_display);
-
-    destroy_bkgnd_surface(wlcontext);
-ErrorContext:
-    destroy_wayland_context(wlcontext);
 
     if(wlcontext->thread_running)
     {
@@ -828,6 +850,11 @@ ErrorContext:
         pthread_join(wlcontext->dlt_ctx_thread, NULL);
         close(wlcontext->pipefd[0]);
     }
+#endif
+
+    destroy_bkgnd_surface(wlcontext);
+ErrorContext:
+    destroy_wayland_context(wlcontext);
 
     free(bkgnd_settings);
     free(wlcontext);

--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -42,6 +42,7 @@
 #include "wayland-util.h"
 
 #define IVI_CLIENT_SURFACE_ID_ENV_NAME "IVI_CLIENT_SURFACE_ID"
+#define IVI_CLIENT_DEBUG_SCOPES_ENV_NAME "IVI_CLIENT_DEBUG_STREAM_NAMES"
 
 struct ivilayer;
 struct iviscreen;
@@ -1976,6 +1977,10 @@ get_config(struct weston_compositor *compositor, struct ivishell *shell)
                        "bkgnd-surface-id",
                        &shell->bkgnd_surface_id, -1);
 
+	weston_config_section_get_string(section,
+	                   "debug-scopes",
+	                   &shell->debug_scopes, NULL);
+
 	weston_config_section_get_color(section,
                        "bkgnd-color",
                        &shell->bkgnd_color, 0xFF000000);
@@ -2163,6 +2168,10 @@ launch_client_process(void *data)
 
     sprintf(option, "%d", shell->bkgnd_surface_id);
     setenv(IVI_CLIENT_SURFACE_ID_ENV_NAME, option, 0x1);
+    if (shell->debug_scopes) {
+        setenv(IVI_CLIENT_DEBUG_SCOPES_ENV_NAME, shell->debug_scopes, 0x1);
+        free(shell->debug_scopes);
+    }
 
     shell->client = weston_client_start(shell->compositor,
                                         shell->ivi_client_name);

--- a/weston-ivi-shell/src/ivi-controller.h
+++ b/weston-ivi-shell/src/ivi-controller.h
@@ -92,6 +92,7 @@ struct ivishell {
 
     struct wl_client *client;
     char *ivi_client_name;
+    char *debug_scopes;
 };
 
 #endif /* WESTON_IVI_SHELL_SRC_IVI_CONTROLLER_H_ */


### PR DESCRIPTION
These patches are related to weston-debug feature and dlt addition in weston-helper client.

PFB the details of changes made:
1) Based on the libweston-6-protocols pkgconfig file availability, decide whether to have the debug-protocol support or not.
2) Added new config option for debug-scopes. User desired debug-scopes are read from weston-ini and exported to weston-client through thorugh ivi-controller.
3) Route the weston logs to dlt. Weston will write to stdout through weston-debug protocol
and the dlt_ctx_thread will read from stdin