### PR TITLE
Fix segmentation fault observed at compositor termination

### DIFF
--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -1565,7 +1565,7 @@ output_destroyed_event(struct wl_listener *listener, void *data)
             destroy_screen(iviscrn);
     }
 
-    if (shell->bkgnd_view)
+    if (shell->bkgnd_view && shell->client)
         set_bkgnd_surface_prop(shell);
     else
         weston_compositor_schedule_repaint(shell->compositor);
@@ -1576,7 +1576,7 @@ output_resized_event(struct wl_listener *listener, void *data)
 {
     struct ivishell *shell = wl_container_of(listener, shell, output_destroyed);
 
-    if (shell->bkgnd_view)
+    if (shell->bkgnd_view && shell->client)
         set_bkgnd_surface_prop(shell);
 }
 
@@ -1588,7 +1588,7 @@ output_created_event(struct wl_listener *listener, void *data)
 
     create_screen(shell, created_output);
 
-    if (shell->bkgnd_view)
+    if (shell->bkgnd_view && shell->client)
         set_bkgnd_surface_prop(shell);
     else
         weston_compositor_schedule_repaint(shell->compositor);
@@ -2028,6 +2028,11 @@ ivi_shell_destroy(struct wl_listener *listener, void *data)
 	struct ivishell *shell =
 		wl_container_of(listener, shell, destroy_listener);
 
+        if (shell->client) {
+            wl_list_remove(&shell->client_destroy_listener.link);
+            wl_client_destroy(shell->client);
+        }
+
 	wl_list_remove(&shell->destroy_listener.link);
 
 	wl_list_remove(&shell->output_created.link);
@@ -2160,6 +2165,18 @@ load_input_module(struct ivishell *shell)
 }
 
 static void
+ivi_shell_client_destroy(struct wl_listener *listener, void *data)
+{
+    struct ivishell *shell = wl_container_of(listener, shell,
+                                             client_destroy_listener);
+
+    weston_log("ivi shell client %p destroyed \n", shell->client);
+
+    wl_list_remove(&shell->client_destroy_listener.link);
+    shell->client = NULL;
+}
+
+static void
 launch_client_process(void *data)
 {
     struct ivishell *shell =
@@ -2175,6 +2192,10 @@ launch_client_process(void *data)
 
     shell->client = weston_client_start(shell->compositor,
                                         shell->ivi_client_name);
+
+    shell->client_destroy_listener.notify = ivi_shell_client_destroy;
+    wl_client_add_destroy_listener(shell->client,
+                                   &shell->client_destroy_listener);
 
     free(shell->ivi_client_name);
 }

--- a/weston-ivi-shell/src/ivi-controller.h
+++ b/weston-ivi-shell/src/ivi-controller.h
@@ -80,6 +80,8 @@ struct ivishell {
 
     struct wl_listener destroy_listener;
 
+    struct wl_listener client_destroy_listener;
+
     struct wl_array screen_ids;
     uint32_t screen_id_offset;
 


### PR DESCRIPTION
A segmentation fault is observed on compositor de-init, if the simple-weston-client is already killed.
Here in termination sequence set_bkgnd_surface_prop function is called without active simple-weston-client resulting in segfault.
set_bkgnd_surface_prop function should be called only when the client is active.