### PR TITLE
Make cursor creation optional

### DIFF
--- a/weston-ivi-shell/src/ivi-controller.c
+++ b/weston-ivi-shell/src/ivi-controller.c
@@ -43,6 +43,7 @@
 
 #define IVI_CLIENT_SURFACE_ID_ENV_NAME "IVI_CLIENT_SURFACE_ID"
 #define IVI_CLIENT_DEBUG_SCOPES_ENV_NAME "IVI_CLIENT_DEBUG_STREAM_NAMES"
+#define IVI_CLIENT_ENABLE_CURSOR_ENV_NAME "IVI_CLIENT_ENABLE_CURSOR"
 
 struct ivilayer;
 struct iviscreen;
@@ -1985,6 +1986,10 @@ get_config(struct weston_compositor *compositor, struct ivishell *shell)
                        "bkgnd-color",
                        &shell->bkgnd_color, 0xFF000000);
 
+	weston_config_section_get_bool(section,
+	                   "enable-cursor",
+	                   &shell->enable_cursor, 0);
+
 	wl_array_init(&shell->screen_ids);
 
 	while (weston_config_next_section(config, &section, &name)) {
@@ -2171,6 +2176,10 @@ launch_client_process(void *data)
     if (shell->debug_scopes) {
         setenv(IVI_CLIENT_DEBUG_SCOPES_ENV_NAME, shell->debug_scopes, 0x1);
         free(shell->debug_scopes);
+    }
+    if(shell->enable_cursor) {
+      sprintf(option, "%d", shell->enable_cursor);
+      setenv(IVI_CLIENT_ENABLE_CURSOR_ENV_NAME, option, 0x1);
     }
 
     shell->client = weston_client_start(shell->compositor,

--- a/weston-ivi-shell/src/ivi-controller.h
+++ b/weston-ivi-shell/src/ivi-controller.h
@@ -85,6 +85,7 @@ struct ivishell {
 
     int32_t bkgnd_surface_id;
     uint32_t bkgnd_color;
+    uint8_t enable_cursor;
     struct ivisurface *bkgnd_surface;
     struct weston_layer bkgnd_layer;
     struct weston_view  *bkgnd_view;


### PR DESCRIPTION
By default the cursor wont be created, If the user wants then the "enable-cursor" option can be added as true in the ivi-shell section of weston config file, as shown below:

    [ivi-shell]
    ...
    enable-cursor=true