### PR TITLE
cmake: add missing include of GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 project(wayland-ivi-extension)
 
+include(GNUInstallDirs)
+
 SET(IVI_EXTENSION_VERSION 2.2.0)
 SET(ILM_API_VERSION 2.2.0)
 


### PR DESCRIPTION
CMAKE_INSTALL_LIBDIR (at least) is used, so GNUInstallDirs needs
to be included. Otherwise it might expand to empty.