### PR TITLE
Implement a shutdown notification for ilm

### DIFF
--- a/ivi-layermanagement-api/ilmCommon/include/ilm_common.h
+++ b/ivi-layermanagement-api/ilmCommon/include/ilm_common.h
@@ -65,6 +65,19 @@ t_ilm_bool ilm_isInitialized(void);
 ilmErrorTypes ilm_commitChanges(void);
 
 /**
+ * \brief register for notification on an event of ilm shutdown
+ * \ingroup ilmCommon
+ * \param[in] callback pointer to function to be called for notification
+              callback function is defined as:
+              void cb(t_ilm_shutdown_error_type error_type, int errornum, void *user_data)
+ * \param[in] user_data pointer to data which will be passed to a notification callback
+ * \return ILM_SUCCESS if the method call was successful
+ * \return ILM_FAILED if the client can not call the method on the service.
+ */
+ilmErrorTypes ilm_registerShutdownNotification(shutdownNotificationFunc callback,
+					       void *user_data);
+
+/**
  * \brief Destroys the IVI LayerManagement Client.
  * \ingroup ilmCommon
  * \return ILM_SUCCESS if the method call was successful

--- a/ivi-layermanagement-api/ilmCommon/include/ilm_types.h
+++ b/ivi-layermanagement-api/ilmCommon/include/ilm_types.h
@@ -249,6 +249,16 @@ typedef enum
 } t_ilm_notification_mask;
 
 /**
+ * enum representing types of possible unrecoverable errors that could lead to ilm shutdown.
+ */
+typedef enum
+{
+    ILM_ERROR_WAYLAND = 1,          /*!< ErrorCode if Wayland API returns an error */
+    ILM_ERROR_POLL = 2              /*!< ErrorCode if Poll returns an error */
+}t_ilm_shutdown_error_type;
+
+
+/**
  * Typedef for notification callback on property changes of a layer
  */
 typedef void(*layerNotificationFunc)(t_ilm_layer layer,
@@ -270,4 +280,11 @@ typedef void(*notificationFunc)(ilmObjectType object,
                                         t_ilm_bool created,
                                         void* user_data);
 
+/**
+ * Typedef for notification callback on ilm shutdown due to unrecoverable
+ * errors
+ */
+typedef void(*shutdownNotificationFunc)(t_ilm_shutdown_error_type error_type,
+                                        int errornum,
+                                        void* user_data);
 #endif /* _ILM_TYPES_H_*/

--- a/ivi-layermanagement-api/ilmCommon/src/ilm_common.c
+++ b/ivi-layermanagement-api/ilmCommon/src/ilm_common.c
@@ -26,6 +26,9 @@
 #include "ilm_types.h"
 
 ILM_EXPORT ilmErrorTypes ilmControl_init(t_ilm_nativedisplay);
+ILM_EXPORT ilmErrorTypes ilmControl_registerShutdownNotification(
+				shutdownNotificationFunc callback,
+				void *user_data);
 ILM_EXPORT void ilmControl_destroy(void);
 
 static pthread_mutex_t g_initialize_lock = PTHREAD_MUTEX_INITIALIZER;
@@ -95,6 +98,12 @@ ilm_isInitialized(void)
         return gIlmCommonPlatformFunc.isInitialized();
 
     return ILM_FALSE;
+}
+
+ILM_EXPORT ilmErrorTypes
+ilm_registerShutdownNotification(shutdownNotificationFunc callback, void *user_data)
+{
+    return ilmControl_registerShutdownNotification(callback, user_data);
 }
 
 ILM_EXPORT ilmErrorTypes

--- a/ivi-layermanagement-api/ilmControl/include/ilm_control_platform.h
+++ b/ivi-layermanagement-api/ilmControl/include/ilm_control_platform.h
@@ -58,6 +58,9 @@ struct ilm_control_context {
     pthread_mutex_t mutex;
     int shutdown_fd;
     uint32_t internal_id_surface;
+
+    shutdownNotificationFunc notification;
+    void *notification_user_data;
 };
 
 struct seat_context {

--- a/ivi-layermanagement-examples/layer-add-surfaces/src/layer-add-surfaces.c
+++ b/ivi-layermanagement-examples/layer-add-surfaces/src/layer-add-surfaces.c
@@ -96,6 +96,35 @@ static void callbackFunction(ilmObjectType object, t_ilm_uint id, t_ilm_bool cre
     }
 }
 
+static void shutdownCallbackFunction(t_ilm_shutdown_error_type error_type,
+                                     int errornum,
+                                     void *user_data)
+{
+    (void) user_data;
+
+    switch (error_type) {
+        case ILM_ERROR_WAYLAND:
+        {
+            printf("layer-add-surfaces: exit, ilm shutdown due to wayland error: %s\n",
+                   strerror(errornum));
+            break;
+        }
+        case ILM_ERROR_POLL:
+        {
+            printf("layer-add-surfaces: exit, ilm shutdown due to poll error: %s\n",
+                   strerror(errornum));
+            break;
+        }
+        default:
+        {
+            printf("layer-add-surfaces: exit, ilm shutdown due to unknown reason: %s\n",
+                   strerror(errornum));
+        }
+    }
+
+    exit(1);
+}
+
 /* Choose the display with the largest resolution.*/
 static t_ilm_uint choose_screen(void)
 {
@@ -234,6 +263,8 @@ int main (int argc, char *argv[])
         fprintf(stderr, "layer-add-surfaces: ilm_init failed\n");
         return -1;
     }
+
+    ilm_registerShutdownNotification(shutdownCallbackFunction, NULL);
 
     screen_ID = choose_screen();
     ilm_layerCreateWithDimension(&layer, screenWidth, screenHeight);


### PR DESCRIPTION
We should gracefully exit when we encounter some unrecoverable errors in ilmControl, e.g.: OOM or wayland errors.
But before we exit, we have to send a notification to the application side that we are shutting down and releasing all resources.