### PR TITLE
ilmCommon: Fix segmentation fault when ilm_isInitialized is called before ilm_init

### DIFF
--- a/ivi-layermanagement-api/ilmCommon/src/ilm_common.c
+++ b/ivi-layermanagement-api/ilmCommon/src/ilm_common.c
@@ -91,7 +91,10 @@ ilm_initWithNativedisplay(t_ilm_nativedisplay nativedisplay)
 ILM_EXPORT t_ilm_bool
 ilm_isInitialized(void)
 {
-    return gIlmCommonPlatformFunc.isInitialized();
+    if(gIlmCommonPlatformFunc.isInitialized)
+        return gIlmCommonPlatformFunc.isInitialized();
+
+    return ILM_FALSE;
 }
 
 ILM_EXPORT ilmErrorTypes


### PR DESCRIPTION
Segmentation fault is observed when ilm_isInitialized is called and if ilm_init was not called before. Here gIlmComonPlatformFunc is initialized in ilm_init using init_ilmCommonPlatformTable, so without calling ilm_init, gIlmCommonPlatformFunc.isInitialized is NULL. Hence calling ilm_isInitialized results in segfault.
Check whether gIlmComonPlatformFunc is initialized. ilm_isInitialized should be called only when gIlmComonPlatformFunc is initialized.

Signed-off-by: Shivakumar Halagatti <Shivakumar.Halagatti@in.bosch.com>