### PR TITLE
Fix compiler warnings

### DIFF
--- a/ivi-layermanagement-api/test/ilm_input_test.cpp
+++ b/ivi-layermanagement-api/test/ilm_input_test.cpp
@@ -125,8 +125,9 @@ TEST_F(IlmInputTest, ilm_input_focus) {
     for (unsigned int i = 0; i < num_ids; i++) {
         /* All surfaces now have keyboard focus */
         for (unsigned int j = 0; j < surfaceCount; j++) {
-            if (surfaceIDs[i] == surfaces[j])
+            if (surfaceIDs[i] == surfaces[j]) {
                 EXPECT_EQ(bitmasks[i], ILM_INPUT_DEVICE_KEYBOARD);
+            }
         }
     }
     free(surfaceIDs);
@@ -136,9 +137,11 @@ TEST_F(IlmInputTest, ilm_input_focus) {
     ASSERT_EQ(ILM_SUCCESS, ilm_setInputFocus(&surfaces[0], 1, ILM_INPUT_DEVICE_KEYBOARD, ILM_FALSE));
     ASSERT_EQ(ILM_SUCCESS, ilm_getInputFocus(&surfaceIDs, &bitmasks, &num_ids));
     /* keyboard focus now removed for surfaces[0] */
-    for (unsigned int i = 0; i < num_ids; i++)
-        if (surfaceIDs[i] == surfaces[0])
+    for (unsigned int i = 0; i < num_ids; i++) {
+        if (surfaceIDs[i] == surfaces[0]) {
             EXPECT_EQ(bitmasks[i], 0);
+        }
+    }
     free(surfaceIDs);
     free(bitmasks);
 
@@ -146,9 +149,11 @@ TEST_F(IlmInputTest, ilm_input_focus) {
     ASSERT_EQ(ILM_SUCCESS, ilm_setInputFocus(&surfaces[1], 1, ILM_INPUT_DEVICE_POINTER, ILM_TRUE));
     ASSERT_EQ(ILM_SUCCESS, ilm_getInputFocus(&surfaceIDs, &bitmasks, &num_ids));
     /* surfaces[1] now has pointer and keyboard focus */
-    for (unsigned int i = 0; i < num_ids; i++)
-        if (surfaceIDs[i] == surfaces[1])
+    for (unsigned int i = 0; i < num_ids; i++) {
+        if (surfaceIDs[i] == surfaces[1]) {
             EXPECT_EQ(bitmasks[i], ILM_INPUT_DEVICE_POINTER | ILM_INPUT_DEVICE_KEYBOARD);
+        }
+    }
     free(surfaceIDs);
     free(bitmasks);
 
@@ -156,9 +161,11 @@ TEST_F(IlmInputTest, ilm_input_focus) {
     ASSERT_EQ(ILM_SUCCESS, ilm_setInputFocus(&surfaces[2], 1, ILM_INPUT_DEVICE_TOUCH, ILM_TRUE));
     ASSERT_EQ(ILM_SUCCESS, ilm_getInputFocus(&surfaceIDs, &bitmasks, &num_ids));
     /* surfaces[2] now has keyboard and touch focus */
-    for (unsigned int i = 0; i < num_ids; i++)
-        if (surfaceIDs[i] == surfaces[2])
+    for (unsigned int i = 0; i < num_ids; i++) {
+        if (surfaceIDs[i] == surfaces[2]) {
             EXPECT_EQ(bitmasks[i], ILM_INPUT_DEVICE_KEYBOARD | ILM_INPUT_DEVICE_TOUCH);
+        }
+    }
     free(surfaceIDs);
     free(bitmasks);
 }

--- a/ivi-layermanagement-examples/EGLWLMockNavigation/src/TextureLoader.cpp
+++ b/ivi-layermanagement-examples/EGLWLMockNavigation/src/TextureLoader.cpp
@@ -67,7 +67,8 @@ bool TextureLoader::loadBMP(const char * imagePath) {
     }
 
     data = new unsigned char [imageSize];
-    fread(data,1,imageSize,file);
+    if(fread(data,1,imageSize,file) != imageSize)
+	cout << "Reading error : mismatch in imageSize and amount of data read" << endl;
     fclose(file);
 
     if (pixelSizeBits == 32) {

--- a/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
+++ b/ivi-layermanagement-examples/simple-weston-client/src/simple-weston-client.c
@@ -702,7 +702,6 @@ weston_dlt_thread_function(void *data)
     WaylandContextStruct* wlcontext;
     char apid[DLT_ID_SIZE];
     char ctid[DLT_ID_SIZE];
-    char *temp;
     DLT_DECLARE_CONTEXT(weston_dlt_context)
 
     wlcontext = (WaylandContextStruct*)data;
@@ -725,7 +724,8 @@ weston_dlt_thread_function(void *data)
         /* read from std-in(read end of pipe) till newline char*/
         do {
             i++;
-            read(wlcontext->pipefd[0], &str[i], 1);
+            if(read(wlcontext->pipefd[0], &str[i], 1) < 0)
+                printf("read failed : %s", strerror(errno));
         } while (str[i] != '\n');
 
         if (strcmp(str,"")!=0)
@@ -812,7 +812,6 @@ int main (int argc, const char * argv[])
     BkGndSettingsStruct* bkgnd_settings;
 
     struct sigaction sigint;
-    int offset = 0;
     int ret = 0;
 
     sigint.sa_handler = signal_int;
@@ -858,7 +857,9 @@ int main (int argc, const char * argv[])
          * stdin - read end
          * weston will write to stdout and the
          * dlt_ctx_thread will read from stdin */
-        pipe(wlcontext->pipefd);
+        if((pipe(wlcontext->pipefd)) < 0)
+            printf("Error in pipe() processing : %s", strerror(errno));
+
         dup2(wlcontext->pipefd[1], STDOUT_FILENO);
 
         wlcontext->thread_running = 1;

--- a/weston-ivi-shell/src/ivi-controller.h
+++ b/weston-ivi-shell/src/ivi-controller.h
@@ -87,7 +87,7 @@ struct ivishell {
 
     int32_t bkgnd_surface_id;
     uint32_t bkgnd_color;
-    uint8_t enable_cursor;
+    int enable_cursor;
     struct ivisurface *bkgnd_surface;
     struct weston_layer bkgnd_layer;
     struct weston_view  *bkgnd_view;


### PR DESCRIPTION
Solve compiler warnings for unused variable, return type of functions and indentation warnings.